### PR TITLE
False positive being returned by mssql_managed_instance_vulnerability_assessment_enabled.sql check. Closes #79

### DIFF
--- a/query/mysql/mssql_managed_instance_vulnerability_assessment_enabled.sql
+++ b/query/mysql/mssql_managed_instance_vulnerability_assessment_enabled.sql
@@ -4,9 +4,9 @@ with vulnerability_assessments as (
   from
     azure_mssql_managed_instance as i,
     jsonb_array_elements(vulnerability_assessments) a
-    where
-      a -> 'vulnerabilityAssessmentProperties' -> 'recurringScans' ->> 'isEnabled' = 'true'
-      and a ->> 'name' = 'Default'
+  where
+    a -> 'recurringScans' ->> 'isEnabled' = 'true'
+    and a ->> 'name' = 'Default'
 )
 select
   -- Required Columns


### PR DESCRIPTION
### Checklist
- [x] https://github.com/turbot/steampipe-mod-azure-compliance/issues/79
```
Query:
with vulnerability_assessments as (
  select
    distinct i.id as id
  from
    azure_mssql_managed_instance as i,
    jsonb_array_elements(vulnerability_assessments) a
  where
    a -> 'recurringScans' ->> 'isEnabled' = 'true'
    and a ->> 'name' = 'Default'
)
select
  -- Required Columns
  s.id as resource,
  case
    when a.id is not null then 'ok'
    else 'alarm'
  end as status,
  case
    when a.id is not null then s.title || ' vulnerability assessment enabled.'
    else s.title || ' vulnerability assessment disabled.'
  end as reason,
  -- Additional Dimensions
  resource_group,
  sub.display_name as subscription
from
  azure_mssql_managed_instance as s
  left join vulnerability_assessments as a on s.id = a.id,
  azure_subscription as sub
where
  sub.subscription_id = s.subscription_id;
  ```
  Query result:
  ```
[
 {
  "reason": "tets566 vulnerability assessment disabled.",
  "resource": "/subscriptions/d46d7416-f95f-47xxxxxxxxxx/resourceGroups/nist-test_group/providers/Microsoft.Sql/managedInstances/tets566",
  "resource_group": "nist-test_group",
  "status": "alarm",
  "subscription": "newwarriors AAA"
 }
]
```