### PR TITLE
Fix hdinsight_cluster_* queries to validate the provisioning_state closes #92

### DIFF
--- a/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
+++ b/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
@@ -2,12 +2,12 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when provisioning_state = 'Failed' then 'skip'
+    when provisioning_state <> 'Succeeded' then 'skip'
     when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then 'ok'
     else 'alarm'
   end as status,
   case
-    when provisioning_state = 'Failed' then a.name || ' is in failed state.'
+    when provisioning_state <> 'Succeeded' then a.name || ' is in ' || provisioning_state || ' state.'
     when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then a.name || ' encrypted with CMK.'
     else a.name || ' not encrypted with CMK.'
   end as reason,

--- a/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
+++ b/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
@@ -3,12 +3,12 @@ select
   a.id as resource,
   case
     when provisioning_state <> 'Succeeded' then 'skip'
-    when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then 'ok'
+    when disk_encryption_properties -> 'keyName' is not null then 'ok'
     else 'alarm'
   end as status,
   case
     when provisioning_state <> 'Succeeded' then a.name || ' is in ' || provisioning_state || ' state.'
-    when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then a.name || ' encrypted with CMK.'
+    when disk_encryption_properties -> 'keyName' is not null then a.name || ' encrypted with CMK.'
     else a.name || ' not encrypted with CMK.'
   end as reason,
   -- Additional Dimensions

--- a/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
+++ b/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
@@ -2,10 +2,12 @@ select
   -- Required Columns
   a.id as resource,
   case
+    when provisioning_state = 'Failed' then 'skip'
     when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then 'ok'
     else 'alarm'
   end as status,
   case
+    when provisioning_state = 'Failed' then a.name || ' is in failed state.'
     when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then a.name || ' encrypted with CMK.'
     else a.name || ' not encrypted with CMK.'
   end as reason,

--- a/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
+++ b/query/hdinsight/hdinsight_cluster_encrypted_at_rest_with_cmk.sql
@@ -2,11 +2,11 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when disk_encryption_properties -> 'keyName' is not null then 'ok'
+    when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then 'ok'
     else 'alarm'
   end as status,
   case
-    when disk_encryption_properties -> 'keyName' is not null then a.name || ' encrypted with CMK.'
+    when disk_encryption_properties -> 'keyName' is not null and provisioning_state <> 'Failed' then a.name || ' encrypted with CMK.'
     else a.name || ' not encrypted with CMK.'
   end as reason,
   -- Additional Dimensions
@@ -16,4 +16,4 @@ from
   azure_hdinsight_cluster as a,
   azure_subscription as sub
 where
-  sub.subscription_id = a.subscription_id
+  sub.subscription_id = a.subscription_id;

--- a/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
@@ -2,11 +2,11 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when disk_encryption_properties -> 'encryptionAtHost' = 'true' then 'ok'
+    when disk_encryption_properties -> 'encryptionAtHost' = 'true' and provisioning_state <> 'Failed' then 'ok'
     else 'alarm'
   end as status,
   case
-    when disk_encryption_properties -> 'encryptionAtHost' = 'true' then a.name || ' uses encryption at host to encrypt data at rest.'
+    when disk_encryption_properties -> 'encryptionAtHost' = 'true' and provisioning_state <> 'Failed' then a.name || ' uses encryption at host to encrypt data at rest.'
     else a.name || ' not uses encryption at host to encrypt data at rest.'
   end as reason,
   -- Additional Dimensions
@@ -16,4 +16,4 @@ from
   azure_hdinsight_cluster as a,
   azure_subscription as sub
 where
-  sub.subscription_id = a.subscription_id
+  sub.subscription_id = a.subscription_id;

--- a/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
@@ -2,11 +2,13 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when disk_encryption_properties -> 'encryptionAtHost' = 'true' and provisioning_state <> 'Failed' then 'ok'
+    when provisioning_state = 'Failed' then 'skip'
+    when disk_encryption_properties -> 'encryptionAtHost' = 'true' then 'ok'
     else 'alarm'
   end as status,
   case
-    when disk_encryption_properties -> 'encryptionAtHost' = 'true' and provisioning_state <> 'Failed' then a.name || ' uses encryption at host to encrypt data at rest.'
+    when provisioning_state = 'Failed' then a.name || ' is in failed state.'
+    when disk_encryption_properties -> 'encryptionAtHost' = 'true' then a.name || ' uses encryption at host to encrypt data at rest.'
     else a.name || ' not uses encryption at host to encrypt data at rest.'
   end as reason,
   -- Additional Dimensions

--- a/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_at_host_enabled.sql
@@ -2,12 +2,12 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when provisioning_state = 'Failed' then 'skip'
+    when provisioning_state <> 'Succeeded' then 'skip'
     when disk_encryption_properties -> 'encryptionAtHost' = 'true' then 'ok'
     else 'alarm'
   end as status,
   case
-    when provisioning_state = 'Failed' then a.name || ' is in failed state.'
+    when provisioning_state <> 'Succeeded' then a.name || ' is in ' || provisioning_state || ' state.'
     when disk_encryption_properties -> 'encryptionAtHost' = 'true' then a.name || ' uses encryption at host to encrypt data at rest.'
     else a.name || ' not uses encryption at host to encrypt data at rest.'
   end as reason,

--- a/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
@@ -2,11 +2,13 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' and provisioning_state <> 'Failed' then 'ok'
+    when provisioning_state = 'Failed' then 'skip'
+    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then 'ok'
     else 'alarm'
   end as status,
   case
-    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' and provisioning_state <> 'Failed' then a.name || ' encryption in transit enabled.'
+     when provisioning_state = 'Failed' then a.name || ' is in failed state.'
+    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then a.name || ' encryption in transit enabled.'
     else a.name || ' encryption in transit disabled.'
   end as reason,
   -- Additional Dimensions

--- a/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
@@ -2,12 +2,12 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when provisioning_state = 'Failed' then 'skip'
+    when provisioning_state <> 'Succeeded' then 'skip'
     when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then 'ok'
     else 'alarm'
   end as status,
   case
-     when provisioning_state = 'Failed' then a.name || ' is in failed state.'
+     when provisioning_state <> 'Succeeded' then a.name || ' is in ' || provisioning_state || ' state.'
     when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then a.name || ' encryption in transit enabled.'
     else a.name || ' encryption in transit disabled.'
   end as reason,

--- a/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
+++ b/query/hdinsight/hdinsight_cluster_encryption_in_transit_enabled.sql
@@ -2,11 +2,11 @@ select
   -- Required Columns
   a.id as resource,
   case
-    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then 'ok'
+    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' and provisioning_state <> 'Failed' then 'ok'
     else 'alarm'
   end as status,
   case
-    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then a.name || ' encryption in transit enabled.'
+    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' and provisioning_state <> 'Failed' then a.name || ' encryption in transit enabled.'
     else a.name || ' encryption in transit disabled.'
   end as reason,
   -- Additional Dimensions


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked

## Test Results
```
 select
  -- Required Columns
  a.id as resource,
  case
    when provisioning_state = 'Failed' then 'skip'
    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then 'ok'
    else 'alarm'
  end as status,
  case
     when provisioning_state = 'Failed' then a.name || ' is in failed state.'
    when encryption_in_transit_properties -> 'isEncryptionInTransitEnabled' = 'true' then a.name || ' encryption in transit enabled.'
    else a.name || ' encryption in transit disabled.'
  end as reason,
  -- Additional Dimensions
  a.resource_group,
  sub.display_name as subscription
from
  azure_hdinsight_cluster as a,
  azure_subscription as sub
where
  sub.subscription_id = a.subscription_id;
+--------------------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------------+---
| resource                                                                                                                                   | status | reason                             | re
+--------------------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------------+---
| /subscriptions/d46dxxxx-f95f-4771-xxxx-xxxx4c76xxxx/resourceGroups/test-resource-grp/providers/Microsoft.HDInsight/clusters/turbottest4321 | skip   | turbottest4321 is in failed state. | te
+--------------------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------------+--
```