### PR TITLE
Fixed minor copy'n'paste error in documentation

### DIFF
--- a/cis_v150/section_3.sp
+++ b/cis_v150/section_3.sp
@@ -5,7 +5,7 @@ locals {
 }
 
 benchmark "cis_v150_3" {
-  title         = "3 Other Security Considerations"
+  title         = "3 Storage Accounts"
   documentation = file("./cis_v150/docs/cis_v150_3.md")
   children = [
     control.cis_v150_3_1,


### PR DESCRIPTION
Fixed minor copy'n'paste error in documentation.
CIS 1.5.0 Section 3 should be Storage Accounts and not Other Security Considerations (which comes a bit further down)
