### PR TITLE
Cis benchmark v2.0.0 fixes

### DIFF
--- a/cis_v200/section_3.sp
+++ b/cis_v200/section_3.sp
@@ -216,7 +216,7 @@ control "cis_v200_3_13" {
 control "cis_v200_3_14" {
   title         = "3.14 Ensure Storage Logging is Enabled for Table Service for 'Read', 'Write', and 'Delete' Requests"
   description   = "Azure Table storage is a service that stores structured NoSQL data in the cloud, providing a key/attribute store with a schema-less design. Storage Logging happens server-side and allows details for both successful and failed requests to be recorded in the storage account. These logs allow users to see the details of read, write, and delete operations against the tables. Storage Logging log entries contain the following information about individual requests: timing information such as start time, end-to-end latency, and server latency; authentication details; concurrency information; and the sizes of the request and response messages."
-  query         = query.manual_control
+  query         = query.storage_account_table_service_logging_enabled
   documentation = file("./cis_v200/docs/cis_v200_3_14.md")
 
   tags = merge(local.cis_v200_3_common_tags, {

--- a/regulatory_compliance/postgres.sp
+++ b/regulatory_compliance/postgres.sp
@@ -350,7 +350,7 @@ query "postgres_db_server_allow_access_to_azure_services_disabled" {
         azure_postgresql_server,
         jsonb_array_elements(firewall_rules) as r
       where
-        r -> 'FirewallRuleProperties' ->> 'endIpAddress' = '0.0.0.0'
+        r -> 'FirewallRuleProperties' ->> 'endIpAddress' = '255.255.255.255'
         and r -> 'FirewallRuleProperties' ->> 'startIpAddress' = '0.0.0.0'
     )
     select


### PR DESCRIPTION
It's a follow-up of: https://github.com/turbot/steampipe-mod-azure-compliance/issues/159 and https://github.com/turbot/steampipe-mod-azure-compliance/issues/158

Short summary of fixes:
- 3.14 was only fixed in v1.5.0 and was has not been propagated to v2.0.0
- 4.3.7 `endIpAddress` has to be `255.255.255.255` while `0.0.0.0` is only valid for startIpAddress. Azure won't allow to create a firewall rule with endIpAddress `0.0.0.0`

### Checklist
- [x] Issue(s) linked
