### PR TITLE
Fixes CIS v2.0.0 5.1.3, updates monitor_logs_storage_container_not_public_accessible

### DIFF
--- a/cis_v130/section_5.sp
+++ b/cis_v130/section_5.sp
@@ -96,7 +96,7 @@ control "cis_v130_5_1_2" {
 control "cis_v130_5_1_3" {
   title         = "5.1.3 Ensure the storage container storing the activity logs is not publicly accessible"
   description   = "The storage account container containing the activity log export should not be publicly accessible."
-  query         = query.monitor_logs_storage_container_not_public_accessible
+  query         = query.monitor_logs_storage_container_insights_operational_logs_not_public_accessible
   documentation = file("./cis_v130/docs/cis_v130_5_1_3.md")
 
   tags = merge(local.cis_v130_5_1_common_tags, {

--- a/cis_v140/section_5.sp
+++ b/cis_v140/section_5.sp
@@ -96,7 +96,7 @@ control "cis_v140_5_1_2" {
 control "cis_v140_5_1_3" {
   title         = "5.1.3 Ensure the storage container storing the activity logs is not publicly accessible"
   description   = "The storage account container containing the activity log export should not be publicly accessible."
-  query         = query.monitor_logs_storage_container_not_public_accessible
+  query         = query.monitor_logs_storage_container_insights_operational_logs_not_public_accessible
   documentation = file("./cis_v140/docs/cis_v140_5_1_3.md")
 
   tags = merge(local.cis_v140_5_1_common_tags, {

--- a/cis_v150/section_5.sp
+++ b/cis_v150/section_5.sp
@@ -98,7 +98,7 @@ control "cis_v150_5_1_2" {
 control "cis_v150_5_1_3" {
   title         = "5.1.3 Ensure the storage container storing the activity logs is not publicly accessible"
   description   = "The storage account container containing the activity log export should not be publicly accessible."
-  query         = query.monitor_logs_storage_container_not_public_accessible
+  query         = query.monitor_logs_storage_container_insights_operational_logs_not_public_accessible
   documentation = file("./cis_v150/docs/cis_v150_5_1_3.md")
 
   tags = merge(local.cis_v150_5_1_common_tags, {

--- a/cis_v200/section_5.sp
+++ b/cis_v200/section_5.sp
@@ -81,7 +81,7 @@ control "cis_v200_5_1_2" {
 control "cis_v200_5_1_3" {
   title         = "5.1.3 Ensure the Storage Container Storing the Activity Logs is not Publicly Accessible"
   description   = "The storage account container containing the activity log export should not be publicly accessible."
-  query         = query.monitor_logs_storage_container_not_public_accessible
+  query         = query.monitor_logs_storage_container_insights_activity_logs_not_public_accessible
   documentation = file("./cis_v200/docs/cis_v200_5_1_3.md")
 
   tags = merge(local.cis_v200_5_1_common_tags, {

--- a/regulatory_compliance/monitor.sp
+++ b/regulatory_compliance/monitor.sp
@@ -908,7 +908,7 @@ query "monitor_logs_storage_container_encryptes_with_byok" {
   EOQ
 }
 
-query "monitor_logs_storage_container_not_public_accessible" {
+query "monitor_logs_storage_container_insights_operational_logs_not_public_accessible" {
   sql = <<-EOQ
     select
       sc.id as resource,
@@ -928,6 +928,30 @@ query "monitor_logs_storage_container_not_public_accessible" {
       azure_subscription sub
     where
       name = 'insights-operational-logs'
+      and sub.subscription_id = sc.subscription_id;
+  EOQ
+}
+
+query "monitor_logs_storage_container_insights_activity_logs_not_public_accessible" {
+  sql = <<-EOQ
+    select
+      sc.id as resource,
+      case
+        when public_access != 'None' then 'alarm'
+        else 'ok'
+      end as status,
+      case
+        when public_access != 'None'
+          then account_name || ' container insights-activity-logs storing activity logs publicly accessible.'
+        else account_name || ' container insights-activity-logs storing activity logs not publicly accessible.'
+      end as reason
+      ${replace(local.common_dimensions_global_qualifier_sql, "__QUALIFIER__", "sc.")}
+      ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
+    from
+      azure_storage_container sc,
+      azure_subscription sub
+    where
+      name = 'insights-activity-logs'
       and sub.subscription_id = sc.subscription_id;
   EOQ
 }


### PR DESCRIPTION
- updates monitor_logs_storage_container_not_public_accessible to the latest recommendation, to address #184 
- keeps the legacy name, for backward compatibility with subscriptions where activity logs were using the legacy container name
- makes the evidence dynamic, based on the container name

### Checklist
- [ x] Issue(s) linked


### References:
- https://workbench.cisecurity.org/benchmarks/8528/tickets/16383
- <img width="1712" alt="image" src="https://github.com/turbot/steampipe-mod-azure-compliance/assets/18538056/9923076a-f4fc-4279-a412-5a43ab17bdca">


