### PR TITLE
Fixes CIS v2.0.0 5.1.4, updates monitor_logs_storage_container_encryptes_with_byok

### DIFF
--- a/cis_v130/section_5.sp
+++ b/cis_v130/section_5.sp
@@ -110,7 +110,7 @@ control "cis_v130_5_1_3" {
 control "cis_v130_5_1_4" {
   title         = "5.1.4 Ensure the storage account containing the container with activity logs is encrypted with BYOK (Use Your Own Key)"
   description   = "The storage account with the activity log export container is configured to use BYOK (Use Your Own Key)."
-  query         = query.monitor_logs_storage_container_encryptes_with_byok
+  query         = query.monitor_logs_storage_container_insights_operational_logs_encrypted_with_byok
   documentation = file("./cis_v130/docs/cis_v130_5_1_4.md")
 
   tags = merge(local.cis_v130_5_1_common_tags, {

--- a/cis_v140/section_5.sp
+++ b/cis_v140/section_5.sp
@@ -110,7 +110,7 @@ control "cis_v140_5_1_3" {
 control "cis_v140_5_1_4" {
   title         = "5.1.4 Ensure the storage account containing the container with activity logs is encrypted with BYOK (Use Your Own Key)"
   description   = "The storage account with the activity log export container is configured to use BYOK (Use Your Own Key)."
-  query         = query.monitor_logs_storage_container_encryptes_with_byok
+  query         = query.monitor_logs_storage_container_insights_operational_logs_encrypted_with_byok
   documentation = file("./cis_v140/docs/cis_v140_5_1_4.md")
 
   tags = merge(local.cis_v140_5_1_common_tags, {

--- a/cis_v150/section_5.sp
+++ b/cis_v150/section_5.sp
@@ -112,7 +112,7 @@ control "cis_v150_5_1_3" {
 control "cis_v150_5_1_4" {
   title         = "5.1.4 Ensure the storage account containing the container with activity logs is encrypted with Customer Managed Key"
   description   = "Storage accounts with the activity log exports can be configured to use Customer Managed Keys (CMK)."
-  query         = query.monitor_logs_storage_container_encryptes_with_byok
+  query         = query.monitor_logs_storage_container_insights_operational_logs_encrypted_with_byok
   documentation = file("./cis_v150/docs/cis_v150_5_1_4.md")
 
   tags = merge(local.cis_v150_5_1_common_tags, {

--- a/cis_v200/section_5.sp
+++ b/cis_v200/section_5.sp
@@ -95,7 +95,7 @@ control "cis_v200_5_1_3" {
 control "cis_v200_5_1_4" {
   title         = "5.1.4 Ensure the storage account containing the container with activity logs is encrypted with Customer Managed Key"
   description   = "Storage accounts with the activity log exports can be configured to use Customer Managed Keys (CMK)."
-  query         = query.monitor_logs_storage_container_encryptes_with_byok
+  query         = query.monitor_logs_storage_container_insights_activity_logs_encrypted_with_byok
   documentation = file("./cis_v200/docs/cis_v200_5_1_4.md")
 
   tags = merge(local.cis_v200_5_1_common_tags, {

--- a/regulatory_compliance/monitor.sp
+++ b/regulatory_compliance/monitor.sp
@@ -881,7 +881,34 @@ query "monitor_log_alert_sql_firewall_rule" {
   EOQ
 }
 
-query "monitor_logs_storage_container_encryptes_with_byok" {
+query "monitor_logs_storage_container_insights_activity_logs_encrypted_with_byok" {
+  sql = <<-EOQ
+    select
+      a.id as resource,
+      case
+        when a.encryption_key_source = 'Microsoft.Keyvault' then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when a.encryption_key_source = 'Microsoft.Keyvault'
+          then a.name || ' container insights-activity-logs encrypted with BYOK.'
+        else a.name || ' container insights-activity-logs not encrypted with BYOK.'
+      end as reason
+      ${local.tag_dimensions_sql}
+      ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
+    from
+      azure_storage_container c,
+      azure_storage_account a,
+      azure_subscription sub
+    where
+      c.name = 'insights-activity-logs'
+      and c.account_name = a.name
+      and sub.subscription_id = a.subscription_id;
+  EOQ
+}
+
+query "monitor_logs_storage_container_insights_operational_logs_encrypted_with_byok" {
   sql = <<-EOQ
     select
       a.id as resource,


### PR DESCRIPTION
- Follow-up of #185 as it is using the same method to enumerate containers that contain activity logs
- Resolves #186
- Is backward compatible with obsolete containers, as it keeps the former `insights-operational-logs` name in the query


### Checklist
- [x] Issue(s) linked
