### PR TITLE
Fix copy paste error in description of CIS_v150_2_1_9.md

### DIFF
--- a/cis_v150/docs/cis_v150_2_1_9.md
+++ b/cis_v150/docs/cis_v150_2_1_9.md
@@ -2,7 +2,7 @@
 
 Microsoft Defender for Cosmos DB scans all incoming network requests for changes to your virtual machine.
 
-Enabling Microsoft Defender for Container Registries allows for greater defense-indepth, with threat detection provided by the Microsoft Security Response Center (MSRC).
+In scanning Cosmos DB requests within a subscription, requests are compared to a heuristic list of potential security threats. These threats could be a result of a security breach within your services, thus scanning for them could prevent a potential security threat from being introduced.
 
 ## Remediation
 


### PR DESCRIPTION
It seems there was the description of cis_v150/docs/cis_v150_2_1_8.md accidentally copied into cis_v150/docs/cis_v150_2_1_9.md.
