### PR TITLE
docs: remove duplicated 'the'

### DIFF
--- a/cis_v140/docs/cis_v140_2_10.md
+++ b/cis_v140/docs/cis_v140_2_10.md
@@ -13,7 +13,7 @@ Perform the following action to check Defender for Cloud Apps (MCAS):
 1. Go to `Microsoft Defender for Cloud`
 2. Select `Environment Settings` blade
 3. Select `Security policy `blade
-4. Click On `Edit Settings` to alter the the security policy for a subscription
+4. Click On `Edit Settings` to alter the security policy for a subscription
 5. Select the `Integrations` blade
 6. Check/Enable option `Allow Microsoft Defender for Endpoint to access my data`
 7. Select `Save`

--- a/cis_v140/docs/cis_v140_2_9.md
+++ b/cis_v140/docs/cis_v140_2_9.md
@@ -13,7 +13,7 @@ Perform the following action to check Azure Defender is set to On for Endpoint (
 1. Go to `Microsoft Defender for Cloud`
 2. Select `Environment Settings` blade
 3. Select `Security policy `blade
-4. Click On `Edit Settings` to alter the the security policy for a subscription
+4. Click On `Edit Settings` to alter the security policy for a subscription
 5. Select the `Integrations` blade
 6. Check/Enable option `Allow Microsoft Defender for Endpoint to access my data`
 7. Select `Save`

--- a/cis_v150/docs/cis_v150_2_4_1.md
+++ b/cis_v150/docs/cis_v150_2_4_1.md
@@ -13,7 +13,7 @@ Microsoft Defender for Cloud Apps works only with Standard Tier subscriptions.
 1. From Azure Home select the Portal Menu
 2. Select `Microsoft Defender for Cloud`
 3. Select `Security policy` blade
-4. Click On `Edit Settings` to alter the the security policy for a subscription
+4. Click On `Edit Settings` to alter the security policy for a subscription
 5. Select the `Integrations` blade
 6. Check/Enable option `Allow Microsoft Defender for Cloud Apps to access my data`
 7. Select `Save`

--- a/cis_v150/docs/cis_v150_2_4_2.md
+++ b/cis_v150/docs/cis_v150_2_4_2.md
@@ -18,7 +18,7 @@ MDE works only with Standard Tier subscriptions.
 2. Select `Microsoft Defender for Cloud`
 3. Select `Environment Settings` blade
 4. Select `Security policy` blade
-5. Click On `Edit Settings` to alter the the security policy for a subscription
+5. Click On `Edit Settings` to alter the security policy for a subscription
 6. Select the `Integrations` blade
 7. Check/Enable option `Allow Microsoft Defender for Endpoint to access my data`
 8. Select `Save`


### PR DESCRIPTION
This PR removes all of the _duplicated_ "the"s.

Similar to turbot/steampipe-mod-aws-compliance#828.