### PR TITLE
Missing backtick and added hyperlink

### DIFF
--- a/cis_v300/docs/cis_v300_2_9.md
+++ b/cis_v300/docs/cis_v300_2_9.md
@@ -8,11 +8,11 @@ This setting is necessary if you have setup 'Require users to register when sign
 
 ### From Azure Portal
 
-1. From Azure Home select the Portal Menu.
+1. From [Azure Home](https://portal.azure.com/#home) select the Portal Menu.
 2. Select `Microsoft Entra ID`.
 3. Under `Manage`, select `Users`.
 4. Under `Manage`, select `Password reset`.
-5. Under `Manage, select `Registration`.
+5. Under `Manage`, select `Registration`.
 6. Set the `Number of days before users are asked to re-confirm their authentication information` to your organization-defined frequency.
 7. Click `Save`.
 


### PR DESCRIPTION
Without the backtick the syntax is not correct.
![image](https://github.com/user-attachments/assets/4c67363c-8121-4bb6-90b5-0939f01393fc)
