### PR TITLE
Add Azure Connection with Resource Group Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ export PP_VAR_tag_dimensions='["Environment", "Owner"]'
 powerpipe benchmark run azure_compliance.benchmark.cis_v300
 ```
 
+### Resource Group Filtering
+
+You can use the `resource_group_filter` variable to limit benchmark results to specific resource groups. When specified, only resources in the listed resource groups will be included in the benchmark results. This is useful for focusing your compliance checks on specific parts of your Azure environment.
+
+You can configure this filter in your vars file:
+
+```sh
+# In powerpipe.ppvars
+resource_group_filter = ["my-resource-group", "another-resource-group"]
+```
+
+Or pass it on the command line:
+
+```sh
+powerpipe benchmark run azure_compliance.benchmark.cis_v300 --var 'resource_group_filter=["my-resource-group"]'
+```
+
+Or through environment variables:
+
+```sh
+export PP_VAR_resource_group_filter='["my-resource-group", "another-resource-group"]'
+powerpipe benchmark run azure_compliance.benchmark.cis_v300
+```
+
+If `resource_group_filter` is empty (the default), no resource group filtering is applied.
+
 ## Open Source & Contributing
 
 This repository is published under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). Please see our [code of conduct](https://github.com/turbot/.github/blob/main/CODE_OF_CONDUCT.md). We look forward to collaborating with you!

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,6 +103,32 @@ export PP_VAR_tag_dimensions='["Environment", "Owner"]'
 powerpipe benchmark run azure_compliance.benchmark.cis_v300
 ```
 
+### Resource Group Filtering
+
+You can use the `resource_group_filter` variable to limit benchmark results to specific resource groups. When specified, only resources in the listed resource groups will be included in the benchmark results. This is useful for focusing your compliance checks on specific parts of your Azure environment.
+
+You can configure this filter in your vars file:
+
+```sh
+# In powerpipe.ppvars
+resource_group_filter = ["my-resource-group", "another-resource-group"]
+```
+
+Or pass it on the command line:
+
+```sh
+powerpipe benchmark run azure_compliance.benchmark.cis_v300 --var 'resource_group_filter=["my-resource-group"]'
+```
+
+Or through environment variables:
+
+```sh
+export PP_VAR_resource_group_filter='["my-resource-group", "another-resource-group"]'
+powerpipe benchmark run azure_compliance.benchmark.cis_v300
+```
+
+If `resource_group_filter` is empty (the default), no resource group filtering is applied.
+
 ## Open Source & Contributing
 
 This repository is published under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0). Please see our [code of conduct](https://github.com/turbot/.github/blob/main/CODE_OF_CONDUCT.md). We look forward to collaborating with you!

--- a/powerpipe.ppvars.example
+++ b/powerpipe.ppvars.example
@@ -3,4 +3,4 @@ common_dimensions = ["resource_group", "subscription"]
 tag_dimensions    = []
 
 # Resource group filter example
-# resource_group_filter = ["my-resource-group-1", "my-resource-group-2"]
+# resource_group_filter = []

--- a/powerpipe.ppvars.example
+++ b/powerpipe.ppvars.example
@@ -1,3 +1,6 @@
 # Dimensions
 common_dimensions = ["resource_group", "subscription"]
 tag_dimensions    = []
+
+# Resource group filter example
+# resource_group_filter = ["my-resource-group-1", "my-resource-group-2"]

--- a/regulatory_compliance/apimanagement.pp
+++ b/regulatory_compliance/apimanagement.pp
@@ -38,7 +38,10 @@ query "apimanagement_service_with_virtual_network" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_api_management a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -59,6 +62,9 @@ query "apimanagement_service_client_certificate_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_api_management a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/apimanagement.pp
+++ b/regulatory_compliance/apimanagement.pp
@@ -41,7 +41,7 @@ query "apimanagement_service_with_virtual_network" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -65,6 +65,6 @@ query "apimanagement_service_client_certificate_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/appconfiguration.pp
+++ b/regulatory_compliance/appconfiguration.pp
@@ -59,7 +59,7 @@ query "app_configuration_private_link_used" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -80,7 +80,7 @@ query "app_configuration_sku_standard" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -104,6 +104,6 @@ query "app_configuration_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/appconfiguration.pp
+++ b/regulatory_compliance/appconfiguration.pp
@@ -56,7 +56,10 @@ query "app_configuration_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_app_configuration as a,
-      azure_subscription as sub;
+      azure_subscription as sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -74,7 +77,10 @@ query "app_configuration_sku_standard" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_app_configuration as a,
-      azure_subscription as sub;
+      azure_subscription as sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -95,6 +101,9 @@ query "app_configuration_encryption_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_app_configuration as a,
-      azure_subscription as sub;
+      azure_subscription as sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/appservice.pp
+++ b/regulatory_compliance/appservice.pp
@@ -485,7 +485,8 @@ query "appservice_web_app_use_https" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -508,7 +509,8 @@ query "appservice_web_app_incoming_client_cert_on" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -533,7 +535,8 @@ query "appservice_web_app_remote_debugging_disabled" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -556,7 +559,8 @@ query "appservice_function_app_remote_debugging_disabled" {
       azure_app_service_function_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -579,7 +583,8 @@ query "appservice_function_app_latest_tls_version" {
       azure_app_service_function_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -602,7 +607,8 @@ query "appservice_web_app_latest_tls_version" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -625,7 +631,8 @@ query "appservice_function_app_only_https_accessible" {
       azure_app_service_function_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -648,7 +655,8 @@ query "appservice_web_app_use_virtual_service_endpoint" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -688,7 +696,8 @@ query "appservice_api_app_use_https" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -713,7 +722,8 @@ query "appservice_api_app_remote_debugging_disabled" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -753,7 +763,8 @@ query "appservice_api_app_latest_tls_version" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -787,7 +798,8 @@ query "appservice_web_app_diagnostic_logs_enabled" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -811,7 +823,8 @@ query "appservice_web_app_cors_no_star" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -835,7 +848,8 @@ query "appservice_function_app_cors_no_star" {
       azure_app_service_function_app as b,
       azure_subscription as sub
     where
-      sub.subscription_id = b.subscription_id;
+      sub.subscription_id = b.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }
 
@@ -875,7 +889,8 @@ query "appservice_api_app_cors_no_star" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -920,7 +935,8 @@ query "appservice_web_app_uses_managed_identity" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -965,7 +981,8 @@ query "appservice_api_app_uses_managed_identity" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1010,7 +1027,8 @@ query "appservice_function_app_uses_managed_identity" {
       left join all_function_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1050,7 +1068,8 @@ query "appservice_api_app_client_certificates_on" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1090,7 +1109,8 @@ query "appservice_web_app_client_certificates_on" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1113,7 +1133,8 @@ query "appservice_function_app_client_certificates_on" {
       azure_app_service_function_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -1153,7 +1174,8 @@ query "appservice_api_app_ftps_enabled" {
       left join all_api_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1193,7 +1215,8 @@ query "appservice_function_app_ftps_enabled" {
       left join all_function_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1233,7 +1256,8 @@ query "appservice_web_app_ftps_enabled" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1281,7 +1305,8 @@ query "appservice_function_app_latest_http_version" {
       left join all_function_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1304,7 +1329,8 @@ query "appservice_web_app_latest_http_version" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -1338,7 +1364,8 @@ query "app_service_environment_internal_encryption_enabled" {
       left join app_service_environment as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1388,7 +1415,8 @@ query "appservice_function_app_latest_java_version" {
       left join all_function_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1438,7 +1466,8 @@ query "appservice_web_app_latest_java_version" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1488,7 +1517,8 @@ query "appservice_web_app_latest_php_version" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1538,7 +1568,8 @@ query "appservice_function_app_latest_python_version" {
       left join all_function_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1588,7 +1619,8 @@ query "appservice_web_app_latest_python_version" {
       left join all_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1613,7 +1645,8 @@ query "appservice_authentication_enabled" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -1637,6 +1670,7 @@ query "appservice_ftp_deployment_disabled" {
         azure_subscription sub
       where
         sub.subscription_id = fa.subscription_id
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "fa.")}
     union
       select
         wa.id as resource,
@@ -1655,7 +1689,8 @@ query "appservice_ftp_deployment_disabled" {
         azure_app_service_web_app as wa,
         azure_subscription as sub
       where
-        sub.subscription_id = wa.subscription_id;
+        sub.subscription_id = wa.subscription_id
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "wa.")};
   EOQ
 }
 
@@ -1678,7 +1713,8 @@ query "appservice_web_app_register_with_active_directory_enabled" {
       azure_app_service_web_app as app,
       azure_subscription as sub
     where
-      sub.subscription_id = app.subscription_id;
+      sub.subscription_id = app.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "app.")};
   EOQ
 }
 
@@ -1720,7 +1756,8 @@ query "appservice_web_app_latest_dotnet_framework_version" {
       left join all_linux_web_app as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1743,7 +1780,8 @@ query "appservice_web_app_failed_request_tracing_enabled" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1766,7 +1804,8 @@ query "appservice_web_app_http_logs_enabled" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1787,7 +1826,8 @@ query "appservice_web_app_worker_more_than_one" {
       jsonb_array_elements(apps) as p,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1810,7 +1850,8 @@ query "appservice_web_app_slot_use_https" {
       azure_app_service_web_app_slot as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -1833,7 +1874,8 @@ query "appservice_web_app_always_on" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1854,13 +1896,14 @@ query "appservice_plan_minimum_sku" {
       azure_app_service_plan as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
 query "appservice_web_app_health_check_enabled" {
   sql = <<-EOQ
-   select
+    select
       a.id as resource,
       case
         when configuration -> 'properties' ->> 'healthCheckPath' is not null then 'ok'
@@ -1877,7 +1920,8 @@ query "appservice_web_app_health_check_enabled" {
       azure_app_service_web_app as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1900,7 +1944,8 @@ query "appservice_function_app_authentication_on" {
       azure_app_service_function_app fa,
       azure_subscription sub
     where
-      sub.subscription_id = fa.subscription_id;
+      sub.subscription_id = fa.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "fa.")};
   EOQ
 }
 
@@ -1934,6 +1979,7 @@ query "appservice_function_app_restrict_public_acces" {
       left join public_function_app as p on p.id = fa.id,
       azure_subscription sub
     where
-      sub.subscription_id = fa.subscription_id;
+      sub.subscription_id = fa.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "fa.")};
   EOQ
 }

--- a/regulatory_compliance/automation.pp
+++ b/regulatory_compliance/automation.pp
@@ -46,6 +46,6 @@ query "automation_account_variable_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/automation.pp
+++ b/regulatory_compliance/automation.pp
@@ -43,6 +43,9 @@ query "automation_account_variable_encryption_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_automation_variable as a,
-      azure_subscription as sub;
+      azure_subscription as sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/batch.pp
+++ b/regulatory_compliance/batch.pp
@@ -84,7 +84,8 @@ query "batch_account_logging_enabled" {
       left join logging_details as l on v.name = l.account_name,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -107,7 +108,8 @@ query "batch_account_encrypted_with_cmk" {
       azure_batch_account as batch,
       azure_subscription as sub
     where
-      sub.subscription_id = batch.subscription_id;
+      sub.subscription_id = batch.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "batch.")};
   EOQ
 }
 
@@ -130,6 +132,7 @@ query "batch_account_identity_provider_enabled" {
       azure_batch_account as b,
       azure_subscription as sub
     where
-      sub.subscription_id = b.subscription_id;
+      sub.subscription_id = b.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }

--- a/regulatory_compliance/cognitivesearch.pp
+++ b/regulatory_compliance/cognitivesearch.pp
@@ -116,7 +116,8 @@ query "search_service_logging_enabled" {
       left join logging_details as l on v.name = l.search_service_name,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -139,7 +140,8 @@ query "search_service_uses_sku_supporting_private_link" {
       azure_search_service as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -162,7 +164,8 @@ query "search_service_public_network_access_disabled" {
       azure_search_service as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -195,7 +198,8 @@ query "search_service_uses_private_link" {
       left join search_service_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -218,7 +222,8 @@ query "search_service_uses_managed_identity" {
       azure_search_service as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -238,6 +243,7 @@ query "search_service_replica_count_3" {
       azure_search_service as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/cognitiveservice.pp
+++ b/regulatory_compliance/cognitiveservice.pp
@@ -76,7 +76,10 @@ query "cognitive_service_local_auth_disabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_cognitive_account a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 

--- a/regulatory_compliance/cognitiveservice.pp
+++ b/regulatory_compliance/cognitiveservice.pp
@@ -79,7 +79,7 @@ query "cognitive_service_local_auth_disabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -124,7 +124,8 @@ query "cognitive_account_private_link_used" {
       left join cognitive_account_connections as c on b.id = c.id,
       azure_subscription as sub
     where
-      sub.subscription_id = b.subscription_id;
+      sub.subscription_id = b.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }
 
@@ -147,7 +148,8 @@ query "cognitive_account_public_network_access_disabled" {
       azure_cognitive_account as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -180,7 +182,8 @@ query "cognitive_account_restrict_public_access" {
       left join account_with_public_access_restricted as b on a.id = b.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -215,6 +218,7 @@ query "cognitive_account_encrypted_with_cmk" {
       left join cognitive_account_cmk as c on c.id = s.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/compute.pp
+++ b/regulatory_compliance/compute.pp
@@ -1228,6 +1228,7 @@ query "compute_vm_jit_access_protected" {
         azure_subscription sub
       where
         vm.subscription_id = sub.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")}
     )
     select
       distinct vm.vm_id as resource,
@@ -1249,7 +1250,8 @@ query "compute_vm_jit_access_protected" {
       azure_subscription as sub
       left join compute on true
     where
-      jit.subscription_id = sub.subscription_id;
+      jit.subscription_id = sub.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 

--- a/regulatory_compliance/compute.pp
+++ b/regulatory_compliance/compute.pp
@@ -924,7 +924,7 @@ query "compute_os_and_data_disk_encrypted_with_cmk" {
     where
       disk_state = 'Attached'
       and sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -949,7 +949,7 @@ query "compute_os_and_data_disk_encrypted_with_cmk_and_platform_managed" {
     where
       disk_state = 'Attached'
       and sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -989,7 +989,7 @@ query "compute_vm_restrict_remote_connection_from_accounts_without_password_linu
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1014,7 +1014,7 @@ query "compute_unattached_disk_encrypted_with_cmk" {
     where
       disk_state != 'Attached'
       and sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -1064,7 +1064,7 @@ query "compute_vm_attached_with_network" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1102,7 +1102,7 @@ query "compute_vm_remote_access_restricted_all_ports" {
       azure_compute_virtual_machine as vm
       left join network_sg as sg on sg.network_interfaces @> vm.network_interfaces
       join azure_subscription as sub on sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1210,7 +1210,7 @@ query "compute_vm_tcp_udp_access_restricted_internet" {
     azure_compute_virtual_machine as vm
     left join virtual_machines_with_access as m on lower(m.virtual_machine_id) = lower(vm.id)
     join azure_subscription as sub on sub.subscription_id = vm.subscription_id
-  ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1251,7 +1251,7 @@ query "compute_vm_jit_access_protected" {
       left join compute on true
     where
       jit.subscription_id = sub.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1288,7 +1288,7 @@ query "compute_vm_log_analytics_agent_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1327,7 +1327,7 @@ query "compute_vm_log_analytics_agent_installed_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1362,7 +1362,7 @@ query "compute_vm_malware_agent_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1399,7 +1399,7 @@ query "compute_vm_scale_set_log_analytics_agent_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1433,7 +1433,7 @@ query "compute_vm_disaster_recovery_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1471,7 +1471,7 @@ query "compute_vm_malware_agent_automatic_upgrade_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1509,7 +1509,7 @@ query "compute_vm_scale_set_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1547,7 +1547,7 @@ query "compute_vm_network_traffic_data_collection_windows_agent_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1585,7 +1585,7 @@ query "compute_vm_network_traffic_data_collection_linux_agent_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1609,7 +1609,7 @@ query "compute_vm_uses_azure_resource_manager" {
       azure_subscription as sub
     where
       sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1633,7 +1633,7 @@ query "compute_vm_system_updates_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1680,7 +1680,7 @@ query "compute_vm_vulnerability_assessment_solution_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1719,7 +1719,7 @@ query "compute_vm_guest_configuration_with_user_and_system_assigned_managed_iden
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1756,7 +1756,7 @@ query "compute_vm_passwords_stored_using_reversible_encryption_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1793,7 +1793,7 @@ query "compute_vm_account_with_password_linux" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1830,7 +1830,7 @@ query "compute_vm_ssh_key_authentication_linux" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1869,7 +1869,7 @@ query "compute_vm_guest_configuration_installed_linux" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1904,7 +1904,7 @@ query "compute_vm_guest_configuration_installed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1944,7 +1944,7 @@ query "arc_compute_machine_linux_log_analytics_agent_installed" {
     azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1983,7 +1983,7 @@ query "compute_vm_guest_configuration_installed_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2020,7 +2020,7 @@ query "compute_vm_restrict_previous_24_passwords_resuse_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2057,7 +2057,7 @@ query "compute_vm_max_password_age_70_days_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2094,7 +2094,7 @@ query "compute_vm_min_password_age_1_day_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2131,7 +2131,7 @@ query "compute_vm_password_complexity_setting_enabled_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2168,7 +2168,7 @@ query "compute_vm_min_password_length_14_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2202,7 +2202,7 @@ query "compute_disk_access_uses_private_link" {
       azure_subscription as sub
     where
       sub.subscription_id = b.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }
 
@@ -2277,7 +2277,7 @@ query "arc_compute_machine_windows_log_analytics_agent_installed" {
     azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2314,7 +2314,7 @@ query "compute_vm_guest_configuration_with_system_assigned_managed_identity" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2354,7 +2354,7 @@ query "compute_vm_windows_defender_exploit_guard_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2397,7 +2397,7 @@ query "compute_vm_secure_communication_protocols_configured" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2422,6 +2422,7 @@ query "compute_vm_and_sacle_set_encryption_at_host_enabled" {
         azure_subscription as sub
       where
         sub.subscription_id = a.subscription_id
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
     )
     union
     (
@@ -2443,6 +2444,7 @@ query "compute_vm_and_sacle_set_encryption_at_host_enabled" {
         azure_subscription as sub
       where
         sub.subscription_id = a.subscription_id
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
     )
   EOQ
 }
@@ -2483,7 +2485,7 @@ query "compute_vm_meet_security_baseline_requirements_linux" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2523,7 +2525,7 @@ query "compute_vm_meet_security_baseline_requirements_windows" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2560,7 +2562,7 @@ query "compute_vm_guest_configuration_with_no_managed_identity" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2616,7 +2618,7 @@ query "compute_vm_remote_access_restricted" {
       azure_compute_virtual_machine as vm
       left join network_sg as sg on sg.network_interfaces @> vm.network_interfaces
       join azure_subscription as sub on sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2640,7 +2642,7 @@ query "compute_vm_utilizing_managed_disk" {
       azure_subscription as sub
     where
       sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2681,7 +2683,7 @@ query "compute_vm_data_and_os_disk_uses_managed_disk" {
       azure_subscription as sub
     where
       sub.subscription_id = vm.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2707,7 +2709,7 @@ query "compute_vm_scale_set_automatic_upgrade_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2733,7 +2735,7 @@ query "compute_vm_scale_set_ssh_key_authentication_linux" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2766,7 +2768,7 @@ query "compute_disk_unattached_encrypted_with_cmk" {
     where
       disk_state != 'Attached'
       and sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -2790,7 +2792,7 @@ query "compute_vm_scale_set_uses_managed_disks" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2814,7 +2816,7 @@ query "compute_vm_scale_set_boot_diagnostics_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2840,7 +2842,7 @@ query "compute_windows_vm_secure_boot_enabled" {
         azure_subscription as sub
       where
         sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2864,7 +2866,7 @@ query "compute_disk_public_access_disabled" {
       azure_subscription sub
     where
       sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -2888,6 +2890,6 @@ query "compute_disk_data_access_auth_mode_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = disk.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }

--- a/regulatory_compliance/compute.pp
+++ b/regulatory_compliance/compute.pp
@@ -923,7 +923,8 @@ query "compute_os_and_data_disk_encrypted_with_cmk" {
       azure_subscription sub
     where
       disk_state = 'Attached'
-      and sub.subscription_id = disk.subscription_id;
+      and sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -947,7 +948,8 @@ query "compute_os_and_data_disk_encrypted_with_cmk_and_platform_managed" {
       azure_subscription sub
     where
       disk_state = 'Attached'
-      and sub.subscription_id = disk.subscription_id;
+      and sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -986,7 +988,8 @@ query "compute_vm_restrict_remote_connection_from_accounts_without_password_linu
       left join compute_machine as m on m.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1010,7 +1013,8 @@ query "compute_unattached_disk_encrypted_with_cmk" {
       azure_subscription sub
     where
       disk_state != 'Attached'
-      and sub.subscription_id = disk.subscription_id;
+      and sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -1059,7 +1063,8 @@ query "compute_vm_attached_with_network" {
       left join vm_with_appoved_networks as b on a.id = b.vm_id,
       azure_subscription sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1096,7 +1101,8 @@ query "compute_vm_remote_access_restricted_all_ports" {
     from
       azure_compute_virtual_machine as vm
       left join network_sg as sg on sg.network_interfaces @> vm.network_interfaces
-      join azure_subscription as sub on sub.subscription_id = vm.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1203,7 +1209,8 @@ query "compute_vm_tcp_udp_access_restricted_internet" {
   from
     azure_compute_virtual_machine as vm
     left join virtual_machines_with_access as m on lower(m.virtual_machine_id) = lower(vm.id)
-    join azure_subscription as sub on sub.subscription_id = vm.subscription_id;
+    join azure_subscription as sub on sub.subscription_id = vm.subscription_id
+  ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1278,7 +1285,8 @@ query "compute_vm_log_analytics_agent_installed" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1316,7 +1324,8 @@ query "compute_vm_log_analytics_agent_installed_windows" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1350,7 +1359,8 @@ query "compute_vm_malware_agent_installed" {
       left join malware_agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1386,7 +1396,8 @@ query "compute_vm_scale_set_log_analytics_agent_installed" {
       left join agent_installed_vm_scale_set as b on a.id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1419,7 +1430,8 @@ query "compute_vm_disaster_recovery_enabled" {
       left join vm_dr_enabled as l on lower(vm.id) = lower(l.source_id),
       azure_subscription sub
     where
-      sub.subscription_id = vm.subscription_id;
+      sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1456,7 +1468,8 @@ query "compute_vm_malware_agent_automatic_upgrade_enabled" {
       left join malware_agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1493,7 +1506,8 @@ query "compute_vm_scale_set_logging_enabled" {
       left join malware_agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1530,7 +1544,8 @@ query "compute_vm_network_traffic_data_collection_windows_agent_installed" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1567,7 +1582,8 @@ query "compute_vm_network_traffic_data_collection_linux_agent_installed" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1590,7 +1606,8 @@ query "compute_vm_uses_azure_resource_manager" {
       azure_compute_virtual_machine as vm,
       azure_subscription as sub
     where
-      sub.subscription_id = vm.subscription_id;
+      sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1613,7 +1630,8 @@ query "compute_vm_system_updates_installed" {
       azure_compute_virtual_machine as vm,
       azure_subscription as sub
     where
-      sub.subscription_id = vm.subscription_id;
+      sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -1659,7 +1677,8 @@ query "compute_vm_vulnerability_assessment_solution_enabled" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1697,7 +1716,8 @@ query "compute_vm_guest_configuration_with_user_and_system_assigned_managed_iden
       left join gc_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1733,7 +1753,8 @@ query "compute_vm_passwords_stored_using_reversible_encryption_windows" {
       left join vm_password_reversible_encryption as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1769,7 +1790,8 @@ query "compute_vm_account_with_password_linux" {
       left join vm_ssh_key_auth as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1805,7 +1827,8 @@ query "compute_vm_ssh_key_authentication_linux" {
       left join vm_ssh_key_auth as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1843,7 +1866,8 @@ query "compute_vm_guest_configuration_installed_linux" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1877,7 +1901,8 @@ query "compute_vm_guest_configuration_installed" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1916,7 +1941,8 @@ query "arc_compute_machine_linux_log_analytics_agent_installed" {
     left join compute_machine as m on m.id = a.id,
     azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1954,7 +1980,8 @@ query "compute_vm_guest_configuration_installed_windows" {
       left join agent_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1990,7 +2017,8 @@ query "compute_vm_restrict_previous_24_passwords_resuse_windows" {
       left join vm_enforce_password_history as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2026,7 +2054,8 @@ query "compute_vm_max_password_age_70_days_windows" {
       left join vm_maximum_password_age as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2062,7 +2091,8 @@ query "compute_vm_min_password_age_1_day_windows" {
       left join vm_min_password_age as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2098,7 +2128,8 @@ query "compute_vm_password_complexity_setting_enabled_windows" {
       left join vm_password_complexity_setting as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2134,7 +2165,8 @@ query "compute_vm_min_password_length_14_windows" {
       left join vm_min_password_age as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2167,7 +2199,8 @@ query "compute_disk_access_uses_private_link" {
       left join compute_disk_connection as c on b.id = c.id,
       azure_subscription as sub
     where
-      sub.subscription_id = b.subscription_id;
+      sub.subscription_id = b.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }
 
@@ -2241,7 +2274,8 @@ query "arc_compute_machine_windows_log_analytics_agent_installed" {
     left join compute_machine as m on m.id = a.id,
     azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2277,7 +2311,8 @@ query "compute_vm_guest_configuration_with_system_assigned_managed_identity" {
       left join gc_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2316,7 +2351,8 @@ query "compute_vm_windows_defender_exploit_guard_enabled" {
       left join compute_machine as m on m.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2358,7 +2394,8 @@ query "compute_vm_secure_communication_protocols_configured" {
       left join compute_machine as m on m.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2443,7 +2480,8 @@ query "compute_vm_meet_security_baseline_requirements_linux" {
       left join compute_machine as m on m.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2482,7 +2520,8 @@ query "compute_vm_meet_security_baseline_requirements_windows" {
       left join compute_machine as m on m.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2518,7 +2557,8 @@ query "compute_vm_guest_configuration_with_no_managed_identity" {
       left join gc_installed_vm as b on a.vm_id = b.vm_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2573,7 +2613,8 @@ query "compute_vm_remote_access_restricted" {
     from
       azure_compute_virtual_machine as vm
       left join network_sg as sg on sg.network_interfaces @> vm.network_interfaces
-      join azure_subscription as sub on sub.subscription_id = vm.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2596,7 +2637,8 @@ query "compute_vm_utilizing_managed_disk" {
       azure_compute_virtual_machine as vm,
       azure_subscription as sub
     where
-      sub.subscription_id = vm.subscription_id;
+      sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2636,7 +2678,8 @@ query "compute_vm_data_and_os_disk_uses_managed_disk" {
       left join data_disk_with_no_managed_disk as d on d.vm_id = vm.id,
       azure_subscription as sub
     where
-      sub.subscription_id = vm.subscription_id;
+      sub.subscription_id = vm.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "vm.")};
   EOQ
 }
 
@@ -2661,7 +2704,8 @@ query "compute_vm_scale_set_automatic_upgrade_enabled" {
       azure_compute_virtual_machine_scale_set as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2686,7 +2730,8 @@ query "compute_vm_scale_set_ssh_key_authentication_linux" {
       azure_compute_virtual_machine_scale_set as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2718,7 +2763,8 @@ query "compute_disk_unattached_encrypted_with_cmk" {
       azure_subscription sub
     where
       disk_state != 'Attached'
-      and sub.subscription_id = disk.subscription_id;
+      and sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -2741,7 +2787,8 @@ query "compute_vm_scale_set_uses_managed_disks" {
       azure_compute_virtual_machine_scale_set as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2764,7 +2811,8 @@ query "compute_vm_scale_set_boot_diagnostics_enabled" {
       azure_compute_virtual_machine_scale_set as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2790,6 +2838,7 @@ query "compute_windows_vm_secure_boot_enabled" {
         azure_subscription as sub
       where
         sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -2812,7 +2861,8 @@ query "compute_disk_public_access_disabled" {
       azure_compute_disk disk,
       azure_subscription sub
     where
-      sub.subscription_id = disk.subscription_id;
+      sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }
 
@@ -2835,6 +2885,7 @@ query "compute_disk_data_access_auth_mode_enabled" {
       azure_compute_disk disk,
       azure_subscription sub
     where
-      sub.subscription_id = disk.subscription_id;
+      sub.subscription_id = disk.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "disk.")};
   EOQ
 }

--- a/regulatory_compliance/containerinstance.pp
+++ b/regulatory_compliance/containerinstance.pp
@@ -58,7 +58,8 @@ query "container_instance_container_group_encrypted_using_cmk" {
       azure_container_group as cg,
       azure_subscription as sub
     where
-      sub.subscription_id = cg.subscription_id;
+      sub.subscription_id = cg.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "cg.")};
   EOQ
 }
 
@@ -81,7 +82,8 @@ query "container_instance_container_group_in_virtual_network" {
       azure_container_group as cg,
       azure_subscription as sub
     where
-      sub.subscription_id = cg.subscription_id;
+      sub.subscription_id = cg.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "cg.")};
   EOQ
 }
 
@@ -104,7 +106,8 @@ query "container_instance_container_group_identity_provider_enabled" {
       azure_container_group as cg,
       azure_subscription as sub
     where
-      sub.subscription_id = cg.subscription_id;
+      sub.subscription_id = cg.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "cg.")};
   EOQ
 }
 
@@ -138,6 +141,7 @@ query "container_instance_container_group_secured_environment_variable" {
       left join not_secured_environment_variable_container_group as g on g.id = cg.id,
       azure_subscription as sub
     where
-      sub.subscription_id = cg.subscription_id;
+      sub.subscription_id = cg.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "cg.")};
   EOQ
 }

--- a/regulatory_compliance/containerregistry.pp
+++ b/regulatory_compliance/containerregistry.pp
@@ -127,7 +127,8 @@ query "container_registry_encrypted_with_cmk" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -150,7 +151,8 @@ query "container_registry_restrict_public_access" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -185,7 +187,8 @@ query "container_registry_use_virtual_service_endpoint" {
       left join container_registry_subnet as s on a.name = s.name,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -218,7 +221,8 @@ query "container_registry_uses_private_link" {
       left join container_registry_private_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -241,7 +245,8 @@ query "container_registry_admin_user_disabled" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -264,7 +269,8 @@ query "container_registry_quarantine_policy_enabled" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -287,7 +293,8 @@ query "container_registry_retention_policy_enabled" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -325,7 +332,8 @@ query "container_registry_geo_replication_enabled" {
       left join geo_replication_count as c on a.name = c.name and a.subscription_id = c.subscription_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -348,7 +356,8 @@ query "container_registry_public_network_access_disabled" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -371,6 +380,7 @@ query "container_registry_trust_policy_enabled" {
       azure_container_registry as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }

--- a/regulatory_compliance/containerregistry.pp
+++ b/regulatory_compliance/containerregistry.pp
@@ -128,7 +128,7 @@ query "container_registry_encrypted_with_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -152,7 +152,7 @@ query "container_registry_restrict_public_access" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -188,7 +188,7 @@ query "container_registry_use_virtual_service_endpoint" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -222,7 +222,7 @@ query "container_registry_uses_private_link" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -246,7 +246,7 @@ query "container_registry_admin_user_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -270,7 +270,7 @@ query "container_registry_quarantine_policy_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -357,7 +357,7 @@ query "container_registry_public_network_access_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -381,6 +381,6 @@ query "container_registry_trust_policy_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }

--- a/regulatory_compliance/cosmosdb.pp
+++ b/regulatory_compliance/cosmosdb.pp
@@ -103,7 +103,8 @@ query "cosmosdb_use_virtual_service_endpoint" {
       left join cosmosdb_with_virtual_network as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -134,7 +135,8 @@ query "cosmosdb_account_with_firewall_rules" {
       azure_cosmosdb_account as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -167,7 +169,8 @@ query "cosmosdb_account_uses_private_link" {
       left join cosmosdb_private_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -190,7 +193,8 @@ query "cosmosdb_account_encryption_at_rest_using_cmk" {
       azure_cosmosdb_account as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -213,7 +217,8 @@ query "cosmosdb_account_key_based_metadata_write_access_disabled" {
       azure_cosmosdb_account as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -240,7 +245,8 @@ query "cosmosdb_account_virtual_network_filter_enabled" {
       azure_cosmosdb_account as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -263,6 +269,7 @@ query "cosmosdb_account_uses_aad_and_rbac" {
       azure_cosmosdb_account as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/databoxedge.pp
+++ b/regulatory_compliance/databoxedge.pp
@@ -22,7 +22,7 @@ control "databox_job_double_encryption_enabled" {
   query       = query.manual_control
 
   tags = merge(local.regulatory_compliance_databoxedge_common_tags, {
-    nist_sp_800_53_rev_5  = "true"
+    nist_sp_800_53_rev_5 = "true"
   })
 }
 
@@ -32,7 +32,7 @@ control "databox_job_unlock_password_encrypted_with_cmk" {
   query       = query.manual_control
 
   tags = merge(local.regulatory_compliance_databoxedge_common_tags, {
-    nist_sp_800_53_rev_5  = "true"
+    nist_sp_800_53_rev_5 = "true"
   })
 }
 
@@ -55,6 +55,7 @@ query "databox_edge_device_double_encryption_enabled" {
       azure_databox_edge_device as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/databoxedge.pp
+++ b/regulatory_compliance/databoxedge.pp
@@ -56,6 +56,6 @@ query "databox_edge_device_double_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/datafactory.pp
+++ b/regulatory_compliance/datafactory.pp
@@ -72,7 +72,8 @@ query "data_factory_uses_private_link" {
       left join data_factory_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -95,7 +96,8 @@ query "data_factory_encrypted_with_cmk" {
       azure_data_factory as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -118,7 +120,8 @@ query "data_factory_public_network_access_disabled" {
       azure_data_factory as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -141,6 +144,7 @@ query "data_factory_uses_git_repository" {
       azure_data_factory as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/datalakeanalytics.pp
+++ b/regulatory_compliance/datalakeanalytics.pp
@@ -65,6 +65,6 @@ query "datalake_analytics_account_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/datalakeanalytics.pp
+++ b/regulatory_compliance/datalakeanalytics.pp
@@ -64,6 +64,7 @@ query "datalake_analytics_account_logging_enabled" {
       left join logging_details as l on a.account_id = l.account_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/datalakestore.pp
+++ b/regulatory_compliance/datalakestore.pp
@@ -46,7 +46,8 @@ query "datalake_store_account_encryption_enabled" {
       azure_data_lake_store as b,
       azure_subscription as sub
     where
-      sub.subscription_id = b.subscription_id;
+      sub.subscription_id = b.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "b.")};
   EOQ
 }
 
@@ -97,6 +98,7 @@ query "datalake_store_account_logging_enabled" {
       left join logging_details as l on a.account_id = l.account_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/eventgrid.pp
+++ b/regulatory_compliance/eventgrid.pp
@@ -85,7 +85,7 @@ query "eventgrid_domain_private_link_used" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -114,7 +114,7 @@ query "eventgrid_topic_private_link_used" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -138,7 +138,7 @@ query "eventgrid_domain_restrict_public_access" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -162,7 +162,7 @@ query "eventgrid_domain_identity_provider_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -186,7 +186,7 @@ query "eventgrid_topic_local_auth_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -210,6 +210,6 @@ query "eventgrid_topic_identity_provider_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/eventgrid.pp
+++ b/regulatory_compliance/eventgrid.pp
@@ -82,7 +82,10 @@ query "eventgrid_domain_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_domain a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -108,7 +111,10 @@ query "eventgrid_topic_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_topic a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -129,7 +135,10 @@ query "eventgrid_domain_restrict_public_access" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_domain a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -150,7 +159,10 @@ query "eventgrid_domain_identity_provider_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_domain a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -171,7 +183,10 @@ query "eventgrid_topic_local_auth_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_domain a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -192,6 +207,9 @@ query "eventgrid_topic_identity_provider_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_eventgrid_topic a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/eventhub.pp
+++ b/regulatory_compliance/eventhub.pp
@@ -98,7 +98,8 @@ query "eventhub_namespace_logging_enabled" {
       left join logging_details as l on v.name = l.namespace_name,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -131,7 +132,8 @@ query "eventhub_namespace_use_virtual_service_endpoint" {
       left join eventhub_namesapce_with_virtual_network as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -166,7 +168,8 @@ query "eventhub_namespace_private_link_used" {
       left join eventhub_service_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -189,6 +192,7 @@ query "eventhub_namespace_cmk_encryption_enabled" {
       azure_eventhub_namespace as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/frontdoor.pp
+++ b/regulatory_compliance/frontdoor.pp
@@ -46,6 +46,7 @@ query "frontdoor_waf_enabled" {
       left join frontdoor_with_waf as c on c.front_door_id = a.front_door_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/hdinsight.pp
+++ b/regulatory_compliance/hdinsight.pp
@@ -61,7 +61,8 @@ query "hdinsight_cluster_encryption_at_host_enabled" {
       azure_hdinsight_cluster as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -86,7 +87,8 @@ query "hdinsight_cluster_encrypted_at_rest_with_cmk" {
       azure_hdinsight_cluster as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -111,6 +113,7 @@ query "hdinsight_cluster_encryption_in_transit_enabled" {
       azure_hdinsight_cluster as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/healthcare.pp
+++ b/regulatory_compliance/healthcare.pp
@@ -47,7 +47,8 @@ query "healthcare_fhir_azure_api_encrypted_at_rest_with_cmk" {
       azure_healthcare_service as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -70,6 +71,9 @@ query "healthcare_fhir_uses_private_link" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_healthcare_service a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/healthcare.pp
+++ b/regulatory_compliance/healthcare.pp
@@ -48,7 +48,7 @@ query "healthcare_fhir_azure_api_encrypted_at_rest_with_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -74,6 +74,6 @@ query "healthcare_fhir_uses_private_link" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/hpccache.pp
+++ b/regulatory_compliance/hpccache.pp
@@ -40,6 +40,6 @@ query "hpc_cache_encrypted_with_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/hpccache.pp
+++ b/regulatory_compliance/hpccache.pp
@@ -39,6 +39,7 @@ query "hpc_cache_encrypted_with_cmk" {
       azure_hpc_cache as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/iothub.pp
+++ b/regulatory_compliance/iothub.pp
@@ -83,7 +83,8 @@ query "iot_hub_logging_enabled" {
       left join logging_details as l on a.id = l.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -110,6 +111,7 @@ query "iot_hub_private_link_used" {
       jsonb_array_elements(private_endpoint_connections) as pec,
       azure_subscription sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/keyvault.pp
+++ b/regulatory_compliance/keyvault.pp
@@ -210,7 +210,8 @@ query "keyvault_purge_protection_enabled" {
       azure_key_vault as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -250,7 +251,8 @@ query "keyvault_logging_enabled" {
       logging_details l,
       azure_subscription sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -286,7 +288,8 @@ query "keyvault_vault_use_virtual_service_endpoint" {
       left join keyvault_vault_subnet as s on a.name = s.name,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -309,7 +312,8 @@ query "keyvault_managed_hms_purge_protection_enabled" {
       azure_key_vault_managed_hardware_security_module as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -350,7 +354,8 @@ query "keyvault_managed_hms_logging_enabled" {
       logging_details as l,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -379,7 +384,10 @@ query "keyvault_vault_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_key_vault a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -402,7 +410,10 @@ query "keyvault_vault_public_network_access_disabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_key_vault a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -427,7 +438,8 @@ query "keyvault_key_expiration_set" {
       azure_key_vault_key kvk,
       azure_subscription sub
     where
-      sub.subscription_id = kvk.subscription_id;
+      sub.subscription_id = kvk.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvk.")};
   EOQ
 }
 
@@ -452,7 +464,8 @@ query "keyvault_secret_expiration_set" {
       azure_key_vault_secret as kvs,
       azure_subscription as sub
     where
-      sub.subscription_id = kvs.subscription_id;
+      sub.subscription_id = kvs.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvs.")};
   EOQ
 }
 
@@ -475,7 +488,8 @@ query "keyvault_soft_delete_enabled" {
       azure_key_vault as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -498,7 +512,8 @@ query "keyvault_rbac_enabled" {
       azure_key_vault as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -533,7 +548,8 @@ query "keyvault_with_non_rbac_key_expiration_set" {
       left join non_rbac_vault as v on v.name = kvk.vault_name,
       azure_subscription sub
     where
-      sub.subscription_id = kvk.subscription_id;
+      sub.subscription_id = kvk.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvk.")};
   EOQ
 }
 
@@ -558,7 +574,8 @@ query "keyvault_vault_recoverable" {
       azure_key_vault kv,
       azure_subscription sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -593,7 +610,8 @@ query "keyvault_with_non_rbac_secret_expiration_set" {
       left join non_rbac_vault as v on v.name = kvs.vault_name,
       azure_subscription sub
     where
-      sub.subscription_id = kvs.subscription_id;
+      sub.subscription_id = kvs.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvs.")};
   EOQ
 }
 
@@ -628,7 +646,8 @@ query "keyvault_with_rbac_key_expiration_set" {
       left join rbac_vault as v on v.name = kvk.vault_name,
       azure_subscription sub
     where
-      sub.subscription_id = kvk.subscription_id;
+      sub.subscription_id = kvk.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvk.")};
   EOQ
 }
 
@@ -663,7 +682,8 @@ query "keyvault_with_rbac_secret_expiration_set" {
       left join rbac_vault as v on v.name = kvs.vault_name,
       azure_subscription sub
     where
-      sub.subscription_id = kvs.subscription_id;
+      sub.subscription_id = kvs.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kvs.")};
   EOQ
 }
 
@@ -686,6 +706,7 @@ query "keyvault_firewall_enabled" {
       azure_key_vault kv,
       azure_subscription sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }

--- a/regulatory_compliance/kubernetes.pp
+++ b/regulatory_compliance/kubernetes.pp
@@ -324,7 +324,8 @@ query "kubernetes_instance_rbac_enabled" {
       azure_kubernetes_cluster kc,
       azure_subscription sub
     where
-      sub.subscription_id = kc.subscription_id;
+      sub.subscription_id = kc.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
   EOQ
 }
 
@@ -347,7 +348,8 @@ query "kubernetes_cluster_add_on_azure_policy_enabled" {
       azure_kubernetes_cluster kc,
       azure_subscription sub
     where
-      sub.subscription_id = kc.subscription_id;
+      sub.subscription_id = kc.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
   EOQ
 }
 
@@ -370,7 +372,8 @@ query "kubernetes_cluster_authorized_ip_range_defined" {
       azure_kubernetes_cluster as c,
       azure_subscription as sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -393,7 +396,8 @@ query "kubernetes_cluster_os_and_data_disks_encrypted_with_cmk" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -429,7 +433,8 @@ query "kubernetes_cluster_temp_disks_and_agent_node_pool_cache_encrypted_at_host
       left join kubernetes_cluster as s on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -460,7 +465,8 @@ query "kubernetes_cluster_upgraded_with_non_vulnerable_version" {
       azure_kubernetes_cluster as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -483,7 +489,8 @@ query "kubernetes_cluster_restrict_public_access" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -506,7 +513,8 @@ query "kubernetes_cluster_addon_azure_policy_enabled" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -541,7 +549,8 @@ query "kubernetes_cluster_node_restrict_public_access" {
       left join public_node as n on n.id = c.id,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -564,7 +573,8 @@ query "kubernetes_cluster_sku_standard" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -587,7 +597,8 @@ query "kubernetes_cluster_upgrade_channel" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -610,7 +621,8 @@ query "kubernetes_cluster_logging_enabled" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -633,7 +645,8 @@ query "kubernetes_cluster_key_vault_secret_rotation_enabled" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -666,7 +679,8 @@ query "kubernetes_cluster_max_pod_50" {
       left join max_node as n on n.id = c.id,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -689,7 +703,8 @@ query "kubernetes_cluster_network_policy_enabled" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -712,7 +727,8 @@ query "kubernetes_cluster_network_plugin_azure" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -735,6 +751,7 @@ query "kubernetes_cluster_http_application_routing_disabled" {
       azure_kubernetes_cluster c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }

--- a/regulatory_compliance/kubernetes.pp
+++ b/regulatory_compliance/kubernetes.pp
@@ -325,7 +325,7 @@ query "kubernetes_instance_rbac_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = kc.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
   EOQ
 }
 
@@ -349,7 +349,7 @@ query "kubernetes_cluster_add_on_azure_policy_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = kc.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kc.")};
   EOQ
 }
 
@@ -373,7 +373,7 @@ query "kubernetes_cluster_authorized_ip_range_defined" {
       azure_subscription as sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -397,7 +397,7 @@ query "kubernetes_cluster_os_and_data_disks_encrypted_with_cmk" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -434,7 +434,7 @@ query "kubernetes_cluster_temp_disks_and_agent_node_pool_cache_encrypted_at_host
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -466,7 +466,7 @@ query "kubernetes_cluster_upgraded_with_non_vulnerable_version" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -490,7 +490,7 @@ query "kubernetes_cluster_restrict_public_access" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -514,7 +514,7 @@ query "kubernetes_cluster_addon_azure_policy_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -550,7 +550,7 @@ query "kubernetes_cluster_node_restrict_public_access" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -574,7 +574,7 @@ query "kubernetes_cluster_sku_standard" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -598,7 +598,7 @@ query "kubernetes_cluster_upgrade_channel" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -622,7 +622,7 @@ query "kubernetes_cluster_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -646,7 +646,7 @@ query "kubernetes_cluster_key_vault_secret_rotation_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -680,7 +680,7 @@ query "kubernetes_cluster_max_pod_50" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -704,7 +704,7 @@ query "kubernetes_cluster_network_policy_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -728,7 +728,7 @@ query "kubernetes_cluster_network_plugin_azure" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -752,6 +752,6 @@ query "kubernetes_cluster_http_application_routing_disabled" {
       azure_subscription sub
     where
       sub.subscription_id = c.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }

--- a/regulatory_compliance/kusto.pp
+++ b/regulatory_compliance/kusto.pp
@@ -76,7 +76,8 @@ query "kusto_cluster_encrypted_at_rest_with_cmk" {
       azure_kusto_cluster as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -99,7 +100,8 @@ query "kusto_cluster_disk_encryption_enabled" {
       azure_kusto_cluster as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -122,7 +124,8 @@ query "kusto_cluster_double_encryption_enabled" {
       azure_kusto_cluster as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }
 
@@ -142,6 +145,7 @@ query "kusto_cluster_sku_with_sla" {
       azure_kusto_cluster as kv,
       azure_subscription as sub
     where
-      sub.subscription_id = kv.subscription_id;
+      sub.subscription_id = kv.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "kv.")};
   EOQ
 }

--- a/regulatory_compliance/logic.pp
+++ b/regulatory_compliance/logic.pp
@@ -74,6 +74,7 @@ query "logic_app_workflow_logging_enabled" {
       left join logging_details as l on a.id = l.workflow_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/machinelearning.pp
+++ b/regulatory_compliance/machinelearning.pp
@@ -46,6 +46,7 @@ query "machine_learning_workspace_encrypted_with_cmk" {
       azure_machine_learning_workspace c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }

--- a/regulatory_compliance/mariadb.pp
+++ b/regulatory_compliance/mariadb.pp
@@ -67,7 +67,8 @@ query "mariadb_server_geo_redundant_backup_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_mariadb_server as s
-      join azure_subscription as sub on sub.subscription_id = s.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -90,7 +91,8 @@ query "mariadb_server_public_network_access_disabled" {
       azure_mariadb_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -116,7 +118,8 @@ query "mariadb_server_private_link_used" {
       azure_mariadb_server a,
       azure_subscription sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -139,6 +142,7 @@ query "mariadb_server_ssl_enabled" {
       azure_mariadb_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }

--- a/regulatory_compliance/mariadb.pp
+++ b/regulatory_compliance/mariadb.pp
@@ -68,7 +68,7 @@ query "mariadb_server_geo_redundant_backup_enabled" {
     from
       azure_mariadb_server as s
       join azure_subscription as sub on sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -92,7 +92,7 @@ query "mariadb_server_public_network_access_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -119,7 +119,7 @@ query "mariadb_server_private_link_used" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -143,6 +143,6 @@ query "mariadb_server_ssl_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }

--- a/regulatory_compliance/monitor.pp
+++ b/regulatory_compliance/monitor.pp
@@ -300,7 +300,8 @@ query "monitor_log_profile_enabled_for_all_categories" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_log_profile as p
-      left join azure_subscription sub on sub.subscription_id = p.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = p.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "p.")};
   EOQ
 }
 
@@ -376,7 +377,8 @@ query "monitor_log_profile_enabled_for_all_regions" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_log_profile as p
-      left join azure_subscription sub on sub.subscription_id = p.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = p.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "p.")};
   EOQ
 }
 
@@ -384,11 +386,13 @@ query "log_profile_enabled_for_all_subscription" {
   sql = <<-EOQ
     with log_profiles as (
       select
-        subscription_id
+        subscription_id,
+        resource_group
       from
         azure_log_profile
       group by
-        subscription_id
+        subscription_id,
+        resource_group
     )
     select
       sub.id as resource,
@@ -404,7 +408,8 @@ query "log_profile_enabled_for_all_subscription" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_subscription as sub
-      left join log_profiles as i on i.subscription_id = sub.subscription_id;
+      left join log_profiles as i on i.subscription_id = sub.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")};
   EOQ
 }
 
@@ -413,11 +418,13 @@ query "monitor_application_insights_configured" {
     with application_insights as (
       select
         subscription_id,
+        resource_group,
         count(*) as no_application_insight
       from
         azure_application_insight
       group by
-        subscription_id
+        subscription_id,
+        resource_group
     )
     select
       sub.id as resource,
@@ -433,7 +440,8 @@ query "monitor_application_insights_configured" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_subscription as sub
-      left join application_insights as i on i.subscription_id = sub.subscription_id;
+      left join application_insights as i on i.subscription_id = sub.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")};
   EOQ
 }
 
@@ -481,7 +489,8 @@ query "monitor_diagnostic_settings_captures_proper_categories" {
       enabled_settings sett,
       azure_subscription sub
     where
-      sub.subscription_id = sett.subscription_id;
+      sub.subscription_id = sett.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sett.")};
   EOQ
 }
 
@@ -1158,7 +1167,8 @@ query "monitor_logs_storage_container_insights_operational_logs_encrypted_with_b
     where
       c.name = 'insights-operational-logs'
       and c.account_name = a.name
-      and sub.subscription_id = a.subscription_id;
+      and sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1185,7 +1195,8 @@ query "monitor_logs_storage_container_insights_activity_logs_encrypted_with_byok
     where
       c.name = 'insights-activity-logs'
       and c.account_name = a.name
-      and sub.subscription_id = a.subscription_id;
+      and sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1209,7 +1220,8 @@ query "monitor_logs_storage_container_insights_operational_logs_not_public_acces
       azure_subscription sub
     where
       name = 'insights-operational-logs'
-      and sub.subscription_id = sc.subscription_id;
+      and sub.subscription_id = sc.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sc.")};
   EOQ
 }
 
@@ -1233,7 +1245,8 @@ query "monitor_logs_storage_container_insights_activity_logs_not_public_accessib
       azure_subscription sub
     where
       name = 'insights-activity-logs'
-      and sub.subscription_id = sc.subscription_id;
+      and sub.subscription_id = sc.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sc.")};
   EOQ
 }
 
@@ -1255,7 +1268,8 @@ query "monitor_log_profile_retention_365_days" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_log_profile as p
-      left join azure_subscription sub on sub.subscription_id = p.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = p.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "p.")};
   EOQ
 }
 
@@ -1276,7 +1290,8 @@ query "application_insights_linked_to_log_analytics_workspace" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_application_insight as a
-      left join azure_subscription sub on sub.subscription_id = a.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1297,7 +1312,8 @@ query "application_insights_block_log_ingestion_and_querying_from_public" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_application_insight as a
-      left join azure_subscription sub on sub.subscription_id = a.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -1318,7 +1334,8 @@ query "log_analytics_workspace_block_log_ingestion_and_querying_from_public" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_log_analytics_workspace as w
-      left join azure_subscription sub on sub.subscription_id = w.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = w.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "w.")};
   EOQ
 }
 
@@ -1339,6 +1356,7 @@ query "log_analytics_workspace_block_non_azure_ingestion" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_log_analytics_workspace as w
-      left join azure_subscription sub on sub.subscription_id = w.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = w.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "w.")};
   EOQ
 }

--- a/regulatory_compliance/mysql.pp
+++ b/regulatory_compliance/mysql.pp
@@ -134,33 +134,33 @@ control "mysql_server_min_tls_1_2" {
 }
 
 control "mysql_flexible_server_ssl_enabled" {
-  title         = "Ensure server parameter 'require_secure_transport' is set to 'ON' for MySQL flexible server"
-  description   = "Enable require_secure_transport on MySQL flexible servers."
-  query         = query.mysql_flexible_server_ssl_enabled
+  title       = "Ensure server parameter 'require_secure_transport' is set to 'ON' for MySQL flexible server"
+  description = "Enable require_secure_transport on MySQL flexible servers."
+  query       = query.mysql_flexible_server_ssl_enabled
 
   tags = local.regulatory_compliance_mysql_common_tags
 }
 
 control "mysql_flexible_server_min_tls_1_2" {
-  title         = "Ensure server parameter 'tls_version' is set to 'TLSv1.2' (or higher) for MySQL flexible server"
-  description   = "Ensure tls_version on MySQL flexible servers is set to use TLS version 1.2 or higher."
-  query         = query.mysql_flexible_server_min_tls_1_2
+  title       = "Ensure server parameter 'tls_version' is set to 'TLSv1.2' (or higher) for MySQL flexible server"
+  description = "Ensure tls_version on MySQL flexible servers is set to use TLS version 1.2 or higher."
+  query       = query.mysql_flexible_server_min_tls_1_2
 
   tags = local.regulatory_compliance_mysql_common_tags
 }
 
 control "mysql_flexible_server_audit_logging_enabled" {
-  title         = "Ensure server parameter 'audit_log_enabled' is set to 'ON' for MySQL flexible Server"
-  description   = "Enable audit_log_enabled on MySQL flexible Servers."
-  query         = query.mysql_flexible_server_audit_logging_enabled
+  title       = "Ensure server parameter 'audit_log_enabled' is set to 'ON' for MySQL flexible Server"
+  description = "Enable audit_log_enabled on MySQL flexible Servers."
+  query       = query.mysql_flexible_server_audit_logging_enabled
 
   tags = local.regulatory_compliance_mysql_common_tags
 }
 
 control "mysql_flexible_server_audit_logging_events_connection_set" {
-  title         = "Ensure server parameter 'audit_log_events' has 'CONNECTION' set for MySQL flexible Server"
-  description   = "Set audit_log_enabled to include CONNECTION on MySQL flexible servers."
-  query         = query.mysql_flexible_server_audit_logging_events_connection_set
+  title       = "Ensure server parameter 'audit_log_events' has 'CONNECTION' set for MySQL flexible Server"
+  description = "Set audit_log_enabled to include CONNECTION on MySQL flexible servers."
+  query       = query.mysql_flexible_server_audit_logging_events_connection_set
 
   tags = local.regulatory_compliance_mysql_common_tags
 }
@@ -184,7 +184,8 @@ query "mysql_ssl_enabled" {
       azure_mysql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -207,7 +208,8 @@ query "mysql_db_server_geo_redundant_backup_enabled" {
       azure_mysql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -241,7 +243,8 @@ query "mssql_managed_instance_encryption_at_rest_using_cmk" {
       left join encryption_protector as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -275,7 +278,8 @@ query "mssql_managed_instance_vulnerability_assessment_enabled" {
       left join vulnerability_assessments as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -298,7 +302,8 @@ query "mysql_server_public_network_access_disabled" {
       azure_mysql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -321,7 +326,8 @@ query "mysql_server_infrastructure_encryption_enabled" {
       azure_mysql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -344,7 +350,10 @@ query "mysql_server_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_mysql_server a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -378,7 +387,8 @@ query "mysql_server_encrypted_at_rest_using_cmk" {
       left join mysql_server_encrypted as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -403,7 +413,8 @@ query "mysql_server_audit_logging_enabled" {
       azure_subscription sub
     where
       config ->> 'Name' = 'audit_log_enabled'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -428,7 +439,8 @@ query "mysql_server_audit_logging_events_connection_set" {
       azure_subscription sub
     where
       config ->> 'Name' = 'audit_log_events'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -453,7 +465,8 @@ query "mysql_server_min_tls_1_2" {
       azure_mysql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -486,7 +499,8 @@ query "mysql_flexible_server_ssl_enabled" {
       left join ssl_enabled as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -520,7 +534,8 @@ query "mysql_flexible_server_min_tls_1_2" {
       left join tls_version as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -554,7 +569,8 @@ query "mysql_flexible_server_audit_logging_enabled" {
       left join audit_log_enabled as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -588,6 +604,7 @@ query "mysql_flexible_server_audit_logging_events_connection_set" {
       left join audit_log_events as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/mysql.pp
+++ b/regulatory_compliance/mysql.pp
@@ -185,7 +185,7 @@ query "mysql_ssl_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -209,7 +209,7 @@ query "mysql_db_server_geo_redundant_backup_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -244,7 +244,7 @@ query "mssql_managed_instance_encryption_at_rest_using_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -279,7 +279,7 @@ query "mssql_managed_instance_vulnerability_assessment_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -303,7 +303,7 @@ query "mysql_server_public_network_access_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -327,7 +327,7 @@ query "mysql_server_infrastructure_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -353,7 +353,7 @@ query "mysql_server_private_link_used" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -388,7 +388,7 @@ query "mysql_server_encrypted_at_rest_using_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -414,7 +414,7 @@ query "mysql_server_audit_logging_enabled" {
     where
       config ->> 'Name' = 'audit_log_enabled'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -440,7 +440,7 @@ query "mysql_server_audit_logging_events_connection_set" {
     where
       config ->> 'Name' = 'audit_log_events'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -466,7 +466,7 @@ query "mysql_server_min_tls_1_2" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -500,7 +500,7 @@ query "mysql_flexible_server_ssl_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -535,7 +535,7 @@ query "mysql_flexible_server_min_tls_1_2" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -570,7 +570,7 @@ query "mysql_flexible_server_audit_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -605,6 +605,6 @@ query "mysql_flexible_server_audit_logging_events_connection_set" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/network.pp
+++ b/regulatory_compliance/network.pp
@@ -440,7 +440,7 @@ query "network_security_group_remote_access_restricted" {
       azure_network_security_group as sg
       left join network_sg as nsg on nsg.sg_name = sg.name
       join azure_subscription as sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -486,7 +486,7 @@ query "network_security_group_rdp_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -510,7 +510,7 @@ query "network_watcher_enabled" {
       azure_location loc
       left join azure_network_watcher watcher on watcher.region = loc.name
       join azure_subscription sub on sub.subscription_id = loc.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "watcher.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "watcher.")}
   EOQ
 }
 
@@ -533,7 +533,7 @@ query "network_security_group_subnet_associated" {
       azure_network_security_group as sg
       join azure_subscription as sub on sub.subscription_id = sg.subscription_id
       left join jsonb_array_elements(subnets) as subnet on true
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -556,7 +556,7 @@ query "network_security_group_not_configured_gateway_subnets" {
     from
       azure_subnet as subnet
       join azure_subscription as sub on sub.subscription_id = subnet.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "subnet.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "subnet.")}
   EOQ
 }
 
@@ -581,7 +581,7 @@ query "network_watcher_in_regions_with_virtual_network" {
       azure_virtual_network as a
       left join azure_network_watcher as b on a.region = b.region
       left join azure_subscription sub on sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -618,7 +618,7 @@ query "network_security_group_diagnostic_setting_deployed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -640,7 +640,7 @@ query "application_gateway_waf_enabled" {
     from
       azure_application_gateway as ag
       join azure_subscription as sub on sub.subscription_id = ag.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
   EOQ
 }
 
@@ -672,7 +672,7 @@ query "network_ddos_enabled" {
       azure_virtual_network as a
       left join application_gateway_subnet as b on a.name = b.vn_name
       join azure_subscription sub on sub.subscription_id = a.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -696,7 +696,7 @@ query "network_virtual_network_gateway_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = g.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "g.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "g.")}
   EOQ
 }
 
@@ -720,7 +720,7 @@ query "network_lb_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = l.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
   EOQ
 }
 
@@ -744,7 +744,7 @@ query "network_public_ip_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = i.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
   EOQ
 }
 
@@ -780,7 +780,7 @@ query "network_bastion_host_min_1" {
     from
       azure_subscription as sub
       left join bastion_hosts as i on i.subscription_id = sub.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
   EOQ
 }
 
@@ -840,7 +840,7 @@ query "network_security_group_https_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -886,7 +886,7 @@ query "network_security_group_ssh_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -937,7 +937,7 @@ query "network_security_group_udp_service_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -963,7 +963,7 @@ query "network_sg_flowlog_retention_period_greater_than_90" {
       azure_network_security_group sg
       left join azure_network_watcher_flow_log fl on sg.id = fl.target_resource_id
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -997,7 +997,7 @@ query "network_network_peering_connected" {
       azure_virtual_network as n
       left join disconnected_network_peering as p on p.vn_id = n.id
       join azure_subscription sub on sub.subscription_id = n.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "n.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "n.")}
   EOQ
 }
 
@@ -1050,7 +1050,7 @@ query "network_security_group_restrict_inbound_udp_port_445" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1103,7 +1103,7 @@ query "network_security_group_restrict_inbound_tcp_port_20" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1156,7 +1156,7 @@ query "network_security_group_restrict_inbound_tcp_port_21" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1211,7 +1211,7 @@ query "network_security_group_restrict_inbound_icmp_port" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1266,7 +1266,7 @@ query "network_security_group_restrict_inbound_tcp_port_4333" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1321,7 +1321,7 @@ query "network_security_group_restrict_inbound_tcp_port_3306" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1376,7 +1376,7 @@ query "network_security_group_restrict_inbound_tcp_port_53" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1431,7 +1431,7 @@ query "network_security_group_restrict_inbound_udp_port_53" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1486,7 +1486,7 @@ query "network_security_group_restrict_inbound_udp_port_137" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1541,7 +1541,7 @@ query "network_security_group_restrict_inbound_udp_port_138" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1596,7 +1596,7 @@ query "network_security_group_restrict_inbound_tcp_port_5432" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1651,7 +1651,7 @@ query "network_security_group_restrict_inbound_tcp_port_25" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1706,7 +1706,7 @@ query "network_security_group_restrict_inbound_tcp_port_1433" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1761,7 +1761,7 @@ query "network_security_group_restrict_inbound_udp_port_1434" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1816,7 +1816,7 @@ query "network_security_group_restrict_inbound_tcp_port_23" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1871,7 +1871,7 @@ query "network_security_group_restrict_inbound_tcp_port_5500" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1926,7 +1926,7 @@ query "network_security_group_restrict_inbound_tcp_port_5900" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1981,7 +1981,7 @@ query "network_security_group_restrict_inbound_tcp_port_135" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2036,7 +2036,7 @@ query "network_security_group_restrict_inbound_tcp_port_445" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2081,7 +2081,7 @@ query "network_security_group_outbound_access_restricted" {
       azure_network_security_group sg
       left join unrestricted_outbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2103,7 +2103,7 @@ query "network_sg_flowlog_enabled" {
     from
       azure_network_security_group as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2127,7 +2127,7 @@ query "network_lb_diagnostics_logs_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = l.subscription_id
-      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
+        ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
   EOQ
 }
 
@@ -2149,7 +2149,7 @@ query "network_watcher_flow_log_enabled" {
     from
       azure_network_watcher_flow_log as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2171,7 +2171,7 @@ query "network_watcher_flow_log_traffic_analytics_enabled" {
     from
       azure_network_watcher_flow_log as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2193,6 +2193,6 @@ query "application_gateway_waf_uses_specified_mode" {
     from
       azure_application_gateway as ag
       join azure_subscription as sub on sub.subscription_id = ag.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
   EOQ
 }

--- a/regulatory_compliance/network.pp
+++ b/regulatory_compliance/network.pp
@@ -110,7 +110,7 @@ control "network_ddos_enabled" {
 
 control "network_virtual_network_gateway_no_basic_sku" {
   title       = "Virtual network gateways should use standard SKUs as a minimum"
-  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU’s do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
+  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU's do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
   query       = query.network_virtual_network_gateway_no_basic_sku
 
   tags = local.regulatory_compliance_network_common_tags
@@ -118,7 +118,7 @@ control "network_virtual_network_gateway_no_basic_sku" {
 
 control "network_lb_no_basic_sku" {
   title       = "Network load balancers should use standard SKUs as a minimum"
-  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU’s do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
+  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU's do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
   query       = query.network_lb_no_basic_sku
 
   tags = local.regulatory_compliance_network_common_tags
@@ -126,7 +126,7 @@ control "network_lb_no_basic_sku" {
 
 control "network_public_ip_no_basic_sku" {
   title       = "Network public IPs should use standard SKUs as a minimum"
-  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU’s do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
+  description = "The use of Basic or Free SKUs in Azure whilst cost effective have significant limitations in terms of what can be monitored and what support can be realized from Microsoft. Typically, these SKU's do not have a service SLA and Microsoft will usually refuse to provide support for them. Consequently Basic/Free SKUs should never be used for production workloads."
   query       = query.network_public_ip_no_basic_sku
 
   tags = local.regulatory_compliance_network_common_tags
@@ -439,7 +439,8 @@ query "network_security_group_remote_access_restricted" {
     from
       azure_network_security_group as sg
       left join network_sg as nsg on nsg.sg_name = sg.name
-      join azure_subscription as sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -484,7 +485,8 @@ query "network_security_group_rdp_access_restricted" {
     from
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -507,7 +509,8 @@ query "network_watcher_enabled" {
     from
       azure_location loc
       left join azure_network_watcher watcher on watcher.region = loc.name
-      join azure_subscription sub on sub.subscription_id = loc.subscription_id;
+      join azure_subscription sub on sub.subscription_id = loc.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -529,7 +532,8 @@ query "network_security_group_subnet_associated" {
     from
       azure_network_security_group as sg
       join azure_subscription as sub on sub.subscription_id = sg.subscription_id
-      left join jsonb_array_elements(subnets) as subnet on true;
+      left join jsonb_array_elements(subnets) as subnet on true
+    ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -551,7 +555,8 @@ query "network_security_group_not_configured_gateway_subnets" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_subnet as subnet
-      join azure_subscription as sub on sub.subscription_id = subnet.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = subnet.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -575,7 +580,8 @@ query "network_watcher_in_regions_with_virtual_network" {
     from
       azure_virtual_network as a
       left join azure_network_watcher as b on a.region = b.region
-      left join azure_subscription sub on sub.subscription_id = a.subscription_id;
+      left join azure_subscription sub on sub.subscription_id = a.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -611,7 +617,8 @@ query "network_security_group_diagnostic_setting_deployed" {
       left join logging_details as l on a.name = l.nsg_name,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -632,7 +639,8 @@ query "application_gateway_waf_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_application_gateway as ag
-      join azure_subscription as sub on sub.subscription_id = ag.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = ag.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -663,7 +671,8 @@ query "network_ddos_enabled" {
     from
       azure_virtual_network as a
       left join application_gateway_subnet as b on a.name = b.vn_name
-      join azure_subscription sub on sub.subscription_id = a.subscription_id;
+      join azure_subscription sub on sub.subscription_id = a.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -686,7 +695,8 @@ query "network_virtual_network_gateway_no_basic_sku" {
       azure_virtual_network_gateway as g,
       azure_subscription as sub
     where
-      sub.subscription_id = g.subscription_id;
+      sub.subscription_id = g.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -709,7 +719,8 @@ query "network_lb_no_basic_sku" {
       azure_lb as l,
       azure_subscription as sub
     where
-      sub.subscription_id = l.subscription_id;
+      sub.subscription_id = l.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -732,7 +743,8 @@ query "network_public_ip_no_basic_sku" {
       azure_public_ip as i,
       azure_subscription as sub
     where
-      sub.subscription_id = i.subscription_id;
+      sub.subscription_id = i.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -767,7 +779,8 @@ query "network_bastion_host_min_1" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_subscription as sub
-      left join bastion_hosts as i on i.subscription_id = sub.subscription_id;
+      left join bastion_hosts as i on i.subscription_id = sub.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -826,7 +839,8 @@ query "network_security_group_https_access_restricted" {
     from
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -871,7 +885,8 @@ query "network_security_group_ssh_access_restricted" {
     from
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -921,7 +936,8 @@ query "network_security_group_udp_service_restricted" {
     from
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -946,7 +962,8 @@ query "network_sg_flowlog_retention_period_greater_than_90" {
     from
       azure_network_security_group sg
       left join azure_network_watcher_flow_log fl on sg.id = fl.target_resource_id
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -979,7 +996,8 @@ query "network_network_peering_connected" {
     from
       azure_virtual_network as n
       left join disconnected_network_peering as p on p.vn_id = n.id
-      join azure_subscription sub on sub.subscription_id = n.subscription_id;
+      join azure_subscription sub on sub.subscription_id = n.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1031,7 +1049,8 @@ query "network_security_group_restrict_inbound_udp_port_445" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1083,7 +1102,8 @@ query "network_security_group_restrict_inbound_tcp_port_20" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1135,7 +1155,8 @@ query "network_security_group_restrict_inbound_tcp_port_21" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1189,7 +1210,8 @@ query "network_security_group_restrict_inbound_icmp_port" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1243,7 +1265,8 @@ query "network_security_group_restrict_inbound_tcp_port_4333" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1297,7 +1320,8 @@ query "network_security_group_restrict_inbound_tcp_port_3306" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1351,7 +1375,8 @@ query "network_security_group_restrict_inbound_tcp_port_53" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1405,7 +1430,8 @@ query "network_security_group_restrict_inbound_udp_port_53" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1459,7 +1485,8 @@ query "network_security_group_restrict_inbound_udp_port_137" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1513,7 +1540,8 @@ query "network_security_group_restrict_inbound_udp_port_138" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1567,7 +1595,8 @@ query "network_security_group_restrict_inbound_tcp_port_5432" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1621,7 +1650,8 @@ query "network_security_group_restrict_inbound_tcp_port_25" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1675,7 +1705,8 @@ query "network_security_group_restrict_inbound_tcp_port_1433" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1729,7 +1760,8 @@ query "network_security_group_restrict_inbound_udp_port_1434" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1783,7 +1815,8 @@ query "network_security_group_restrict_inbound_tcp_port_23" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1837,7 +1870,8 @@ query "network_security_group_restrict_inbound_tcp_port_5500" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql}
   EOQ
 }
 
@@ -1891,7 +1925,8 @@ query "network_security_group_restrict_inbound_tcp_port_5900" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -1945,7 +1980,8 @@ query "network_security_group_restrict_inbound_tcp_port_135" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -1999,7 +2035,8 @@ query "network_security_group_restrict_inbound_tcp_port_445" {
     from
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2043,7 +2080,8 @@ query "network_security_group_outbound_access_restricted" {
     from
       azure_network_security_group sg
       left join unrestricted_outbound nsg on nsg.sg_name = sg.name
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+    ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2064,7 +2102,8 @@ query "network_sg_flowlog_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_network_security_group as sg
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2087,7 +2126,8 @@ query "network_lb_diagnostics_logs_enabled" {
       azure_lb as l,
       azure_subscription as sub
     where
-      sub.subscription_id = l.subscription_id;
+      sub.subscription_id = l.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2108,7 +2148,8 @@ query "network_watcher_flow_log_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_network_watcher_flow_log as sg
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2129,7 +2170,8 @@ query "network_watcher_flow_log_traffic_analytics_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_network_watcher_flow_log as sg
-      join azure_subscription sub on sub.subscription_id = sg.subscription_id;
+      join azure_subscription sub on sub.subscription_id = sg.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }
 
@@ -2150,6 +2192,7 @@ query "application_gateway_waf_uses_specified_mode" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_application_gateway as ag
-      join azure_subscription as sub on sub.subscription_id = ag.subscription_id;
+      join azure_subscription as sub on sub.subscription_id = ag.subscription_id
+      ${local.resource_group_filter_sql};
   EOQ
 }

--- a/regulatory_compliance/network.pp
+++ b/regulatory_compliance/network.pp
@@ -440,7 +440,7 @@ query "network_security_group_remote_access_restricted" {
       azure_network_security_group as sg
       left join network_sg as nsg on nsg.sg_name = sg.name
       join azure_subscription as sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -486,7 +486,7 @@ query "network_security_group_rdp_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -510,7 +510,7 @@ query "network_watcher_enabled" {
       azure_location loc
       left join azure_network_watcher watcher on watcher.region = loc.name
       join azure_subscription sub on sub.subscription_id = loc.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "watcher.")}
   EOQ
 }
 
@@ -533,7 +533,7 @@ query "network_security_group_subnet_associated" {
       azure_network_security_group as sg
       join azure_subscription as sub on sub.subscription_id = sg.subscription_id
       left join jsonb_array_elements(subnets) as subnet on true
-    ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -556,7 +556,7 @@ query "network_security_group_not_configured_gateway_subnets" {
     from
       azure_subnet as subnet
       join azure_subscription as sub on sub.subscription_id = subnet.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "subnet.")}
   EOQ
 }
 
@@ -581,7 +581,7 @@ query "network_watcher_in_regions_with_virtual_network" {
       azure_virtual_network as a
       left join azure_network_watcher as b on a.region = b.region
       left join azure_subscription sub on sub.subscription_id = a.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -618,7 +618,7 @@ query "network_security_group_diagnostic_setting_deployed" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${local.resource_group_filter_sql}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -640,7 +640,7 @@ query "application_gateway_waf_enabled" {
     from
       azure_application_gateway as ag
       join azure_subscription as sub on sub.subscription_id = ag.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
   EOQ
 }
 
@@ -672,7 +672,7 @@ query "network_ddos_enabled" {
       azure_virtual_network as a
       left join application_gateway_subnet as b on a.name = b.vn_name
       join azure_subscription sub on sub.subscription_id = a.subscription_id
-      ${local.resource_group_filter_sql};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -696,7 +696,7 @@ query "network_virtual_network_gateway_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = g.subscription_id
-      ${local.resource_group_filter_sql};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "g.")}
   EOQ
 }
 
@@ -720,7 +720,7 @@ query "network_lb_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = l.subscription_id
-      ${local.resource_group_filter_sql};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
   EOQ
 }
 
@@ -744,7 +744,7 @@ query "network_public_ip_no_basic_sku" {
       azure_subscription as sub
     where
       sub.subscription_id = i.subscription_id
-      ${local.resource_group_filter_sql};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
   EOQ
 }
 
@@ -780,7 +780,7 @@ query "network_bastion_host_min_1" {
     from
       azure_subscription as sub
       left join bastion_hosts as i on i.subscription_id = sub.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "i.")}
   EOQ
 }
 
@@ -840,7 +840,7 @@ query "network_security_group_https_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -886,7 +886,7 @@ query "network_security_group_ssh_access_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -937,7 +937,7 @@ query "network_security_group_udp_service_restricted" {
       azure_network_security_group sg
       left join network_sg nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -963,7 +963,7 @@ query "network_sg_flowlog_retention_period_greater_than_90" {
       azure_network_security_group sg
       left join azure_network_watcher_flow_log fl on sg.id = fl.target_resource_id
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -997,7 +997,7 @@ query "network_network_peering_connected" {
       azure_virtual_network as n
       left join disconnected_network_peering as p on p.vn_id = n.id
       join azure_subscription sub on sub.subscription_id = n.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "n.")}
   EOQ
 }
 
@@ -1050,7 +1050,7 @@ query "network_security_group_restrict_inbound_udp_port_445" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1103,7 +1103,7 @@ query "network_security_group_restrict_inbound_tcp_port_20" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1156,7 +1156,7 @@ query "network_security_group_restrict_inbound_tcp_port_21" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1211,7 +1211,7 @@ query "network_security_group_restrict_inbound_icmp_port" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1266,7 +1266,7 @@ query "network_security_group_restrict_inbound_tcp_port_4333" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1321,7 +1321,7 @@ query "network_security_group_restrict_inbound_tcp_port_3306" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1376,7 +1376,7 @@ query "network_security_group_restrict_inbound_tcp_port_53" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1431,7 +1431,7 @@ query "network_security_group_restrict_inbound_udp_port_53" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1486,7 +1486,7 @@ query "network_security_group_restrict_inbound_udp_port_137" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1541,7 +1541,7 @@ query "network_security_group_restrict_inbound_udp_port_138" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1596,7 +1596,7 @@ query "network_security_group_restrict_inbound_tcp_port_5432" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1651,7 +1651,7 @@ query "network_security_group_restrict_inbound_tcp_port_25" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1706,7 +1706,7 @@ query "network_security_group_restrict_inbound_tcp_port_1433" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1761,7 +1761,7 @@ query "network_security_group_restrict_inbound_udp_port_1434" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1816,7 +1816,7 @@ query "network_security_group_restrict_inbound_tcp_port_23" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1871,7 +1871,7 @@ query "network_security_group_restrict_inbound_tcp_port_5500" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql}
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1926,7 +1926,7 @@ query "network_security_group_restrict_inbound_tcp_port_5900" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -1981,7 +1981,7 @@ query "network_security_group_restrict_inbound_tcp_port_135" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2036,7 +2036,7 @@ query "network_security_group_restrict_inbound_tcp_port_445" {
       azure_network_security_group sg
       left join unrestricted_inbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2081,7 +2081,7 @@ query "network_security_group_outbound_access_restricted" {
       azure_network_security_group sg
       left join unrestricted_outbound nsg on nsg.sg_name = sg.name
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-    ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2103,7 +2103,7 @@ query "network_sg_flowlog_enabled" {
     from
       azure_network_security_group as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-      ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2127,7 +2127,7 @@ query "network_lb_diagnostics_logs_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = l.subscription_id
-      ${local.resource_group_filter_sql};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "l.")}
   EOQ
 }
 
@@ -2149,7 +2149,7 @@ query "network_watcher_flow_log_enabled" {
     from
       azure_network_watcher_flow_log as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-      ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2171,7 +2171,7 @@ query "network_watcher_flow_log_traffic_analytics_enabled" {
     from
       azure_network_watcher_flow_log as sg
       join azure_subscription sub on sub.subscription_id = sg.subscription_id
-      ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sg.")}
   EOQ
 }
 
@@ -2193,6 +2193,6 @@ query "application_gateway_waf_uses_specified_mode" {
     from
       azure_application_gateway as ag
       join azure_subscription as sub on sub.subscription_id = ag.subscription_id
-      ${local.resource_group_filter_sql};
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "ag.")}
   EOQ
 }

--- a/regulatory_compliance/postgres.pp
+++ b/regulatory_compliance/postgres.pp
@@ -213,7 +213,7 @@ query "postgres_db_server_geo_redundant_backup_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -237,7 +237,7 @@ query "postgres_sql_ssl_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -261,7 +261,7 @@ query "postgresql_server_public_network_access_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -285,7 +285,7 @@ query "postgresql_server_infrastructure_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -311,8 +311,8 @@ query "postgres_server_private_link_used" {
       azure_postgresql_server a,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -347,7 +347,7 @@ query "postgres_sql_server_encrypted_at_rest_using_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -373,7 +373,7 @@ query "postgres_db_server_connection_throttling_on" {
     where
       config ->> 'Name' = 'connection_throttling'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -399,7 +399,7 @@ query "postgres_db_server_log_checkpoints_on" {
     where
       config ->> 'Name' = 'log_checkpoints'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -425,7 +425,7 @@ query "postgres_db_server_log_connections_on" {
     where
       config ->> 'Name' = 'log_connections'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -451,7 +451,7 @@ query "postgres_db_server_log_disconnections_on" {
     where
       config ->> 'Name' = 'log_disconnections'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -477,7 +477,7 @@ query "postgres_db_server_log_duration_on" {
     where
       config ->> 'Name' = 'log_duration'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -503,7 +503,7 @@ query "postgres_db_server_log_retention_days_3" {
     where
       config ->> 'Name' = 'log_retention_days'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -538,7 +538,7 @@ query "postgres_db_server_allow_access_to_azure_services_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -562,7 +562,7 @@ query "postgres_db_server_latest_tls_version" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -596,7 +596,7 @@ query "postgres_sql_flexible_server_ssl_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -630,7 +630,7 @@ query "postgres_flexible_server_log_checkpoints_on" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -664,7 +664,7 @@ query "postgres_flexible_server_connection_throttling_on" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -690,7 +690,7 @@ query "postgres_flexible_server_log_retention_days_3" {
     where
       config ->> 'Name' = 'logfiles.retention_days'
       and sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -725,6 +725,6 @@ query "postgres_flexible_server_allow_access_to_azure_services_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }

--- a/regulatory_compliance/postgres.pp
+++ b/regulatory_compliance/postgres.pp
@@ -154,41 +154,41 @@ control "postgres_db_server_allow_access_to_azure_services_disabled" {
 }
 
 control "postgres_flexible_server_allow_access_to_azure_services_disabled" {
-  title         = "Ensure 'Allow public access from any Azure service within Azure to this server' for PostgreSQL flexible server is disabled"
-  description   = "Disable access from Azure services to PostgreSQL flexible server."
-  query         = query.postgres_flexible_server_allow_access_to_azure_services_disabled
+  title       = "Ensure 'Allow public access from any Azure service within Azure to this server' for PostgreSQL flexible server is disabled"
+  description = "Disable access from Azure services to PostgreSQL flexible server."
+  query       = query.postgres_flexible_server_allow_access_to_azure_services_disabled
 
   tags = local.regulatory_compliance_postgres_common_tags
 }
 
 control "postgres_sql_flexible_server_ssl_enabled" {
-  title         = "Ensure server parameter 'require_secure_transport' is set to 'ON' for PostgreSQL flexible server"
-  description   = "Enable 'require_secure_transport' on 'PostgreSQL flexible servers'."
-  query         = query.postgres_sql_flexible_server_ssl_enabled
+  title       = "Ensure server parameter 'require_secure_transport' is set to 'ON' for PostgreSQL flexible server"
+  description = "Enable 'require_secure_transport' on 'PostgreSQL flexible servers'."
+  query       = query.postgres_sql_flexible_server_ssl_enabled
 
   tags = local.regulatory_compliance_postgres_common_tags
 }
 
 control "postgres_flexible_server_log_checkpoints_on" {
-  title         = "Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL flexible Server"
-  description   = "Enable 'log_checkpoints' on 'PostgreSQL Servers'."
-  query         = query.postgres_flexible_server_log_checkpoints_on
+  title       = "Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL flexible Server"
+  description = "Enable 'log_checkpoints' on 'PostgreSQL Servers'."
+  query       = query.postgres_flexible_server_log_checkpoints_on
 
   tags = local.regulatory_compliance_postgres_common_tags
 }
 
 control "postgres_flexible_server_connection_throttling_on" {
-  title         = "Ensure server parameter 'connection_throttle.enable' is set to 'ON' for PostgreSQL flexible Server"
-  description   = "Enable connection_throttling on PostgreSQL flexible Servers."
-  query         = query.postgres_flexible_server_connection_throttling_on
+  title       = "Ensure server parameter 'connection_throttle.enable' is set to 'ON' for PostgreSQL flexible Server"
+  description = "Enable connection_throttling on PostgreSQL flexible Servers."
+  query       = query.postgres_flexible_server_connection_throttling_on
 
   tags = local.regulatory_compliance_postgres_common_tags
 }
 
 control "postgres_flexible_server_log_retention_days_3" {
-  title         = "Ensure Server Parameter 'logfiles.retention_days' is greater than 3 days for PostgreSQL flexible Server"
-  description   = "Ensure logfiles.retention_days on PostgreSQL flexible Servers is set to an appropriate value."
-  query         = query.postgres_flexible_server_log_retention_days_3
+  title       = "Ensure Server Parameter 'logfiles.retention_days' is greater than 3 days for PostgreSQL flexible Server"
+  description = "Ensure logfiles.retention_days on PostgreSQL flexible Servers is set to an appropriate value."
+  query       = query.postgres_flexible_server_log_retention_days_3
 
   tags = local.regulatory_compliance_postgres_common_tags
 }
@@ -212,7 +212,8 @@ query "postgres_db_server_geo_redundant_backup_enabled" {
       azure_postgresql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -235,7 +236,8 @@ query "postgres_sql_ssl_enabled" {
       azure_postgresql_server s,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -258,7 +260,8 @@ query "postgresql_server_public_network_access_disabled" {
       azure_postgresql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -281,7 +284,8 @@ query "postgresql_server_infrastructure_encryption_enabled" {
       azure_postgresql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -305,7 +309,10 @@ query "postgres_server_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_postgresql_server a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -339,7 +346,8 @@ query "postgres_sql_server_encrypted_at_rest_using_cmk" {
       left join pgql_server_encrypted as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -364,7 +372,8 @@ query "postgres_db_server_connection_throttling_on" {
       azure_subscription sub
     where
       config ->> 'Name' = 'connection_throttling'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -389,7 +398,8 @@ query "postgres_db_server_log_checkpoints_on" {
       azure_subscription sub
     where
       config ->> 'Name' = 'log_checkpoints'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -414,7 +424,8 @@ query "postgres_db_server_log_connections_on" {
       azure_subscription sub
     where
       config ->> 'Name' = 'log_connections'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -439,7 +450,8 @@ query "postgres_db_server_log_disconnections_on" {
       azure_subscription sub
     where
       config ->> 'Name' = 'log_disconnections'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -464,7 +476,8 @@ query "postgres_db_server_log_duration_on" {
       azure_subscription sub
     where
       config ->> 'Name' = 'log_duration'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -489,7 +502,8 @@ query "postgres_db_server_log_retention_days_3" {
       azure_subscription sub
     where
       config ->> 'Name' = 'log_retention_days'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -523,7 +537,8 @@ query "postgres_db_server_allow_access_to_azure_services_disabled" {
       left join postgres_db_with_allow_access_to_azure_services as a on a.id = s.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -546,7 +561,8 @@ query "postgres_db_server_latest_tls_version" {
       azure_postgresql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -579,7 +595,8 @@ query "postgres_sql_flexible_server_ssl_enabled" {
       left join ssl_enabled as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -612,7 +629,8 @@ query "postgres_flexible_server_log_checkpoints_on" {
       left join log_checkpoints_on as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -645,7 +663,8 @@ query "postgres_flexible_server_connection_throttling_on" {
       left join connection_throttling_on as a on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -670,7 +689,8 @@ query "postgres_flexible_server_log_retention_days_3" {
       azure_subscription sub
     where
       config ->> 'Name' = 'logfiles.retention_days'
-      and sub.subscription_id = s.subscription_id;
+      and sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -704,6 +724,7 @@ query "postgres_flexible_server_allow_access_to_azure_services_disabled" {
       left join postgres_flexible_server_with_allow_access_to_azure_services as a on a.id = s.id,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }

--- a/regulatory_compliance/recoveryservice.pp
+++ b/regulatory_compliance/recoveryservice.pp
@@ -61,7 +61,8 @@ query "recovery_service_vault_uses_managed_identity" {
       azure_recovery_services_vault as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -84,7 +85,8 @@ query "recovery_service_vault_uses_private_link" {
       azure_recovery_services_vault as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -107,6 +109,7 @@ query "recovery_service_vault_uses_private_link_for_backup" {
       azure_recovery_services_vault as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/recoveryservice.pp
+++ b/regulatory_compliance/recoveryservice.pp
@@ -62,7 +62,7 @@ query "recovery_service_vault_uses_managed_identity" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -86,7 +86,7 @@ query "recovery_service_vault_uses_private_link" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -110,6 +110,6 @@ query "recovery_service_vault_uses_private_link_for_backup" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/redis.pp
+++ b/regulatory_compliance/redis.pp
@@ -73,7 +73,8 @@ query "redis_cache_ssl_enabled" {
       azure_redis_cache as redis,
       azure_subscription as sub
     where
-      sub.subscription_id = redis.subscription_id;
+      sub.subscription_id = redis.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "redis.")};
   EOQ
 }
 
@@ -106,7 +107,8 @@ query "redis_cache_uses_private_link" {
       left join redis_private_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -129,7 +131,8 @@ query "redis_cache_in_virtual_network" {
       azure_redis_cache as redis,
       azure_subscription as sub
     where
-      sub.subscription_id = redis.subscription_id;
+      sub.subscription_id = redis.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "redis.")};
   EOQ
 }
 
@@ -152,7 +155,8 @@ query "redis_cache_no_basic_sku" {
       azure_redis_cache as c,
       azure_subscription as sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }
 
@@ -176,6 +180,7 @@ query "redis_cache_min_tls_1_2" {
       azure_redis_cache as c,
       azure_subscription sub
     where
-      sub.subscription_id = c.subscription_id;
+      sub.subscription_id = c.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "c.")};
   EOQ
 }

--- a/regulatory_compliance/servicebus.pp
+++ b/regulatory_compliance/servicebus.pp
@@ -113,7 +113,7 @@ query "servicebus_namespace_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = v.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -142,7 +142,7 @@ query "servicebus_name_space_private_link_used" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -168,7 +168,7 @@ query "servicebus_premium_namespace_cmk_encrypted" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -214,7 +214,7 @@ query "servicebus_use_virtual_service_endpoint" {
       left join service_bus on true
     where
       sub.subscription_id = bus.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "bus.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "bus.")};
   EOQ
 }
 
@@ -240,7 +240,7 @@ query "servicebus_namespace_azure_ad_authentication_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -270,6 +270,6 @@ query "servicebus_namespace_no_overly_permissive_network_access" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/servicebus.pp
+++ b/regulatory_compliance/servicebus.pp
@@ -112,7 +112,8 @@ query "servicebus_namespace_logging_enabled" {
       left join logging_details as l on v.name = l.namespace_name,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }
 
@@ -138,7 +139,10 @@ query "servicebus_name_space_private_link_used" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_servicebus_namespace a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -161,7 +165,10 @@ query "servicebus_premium_namespace_cmk_encrypted" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_servicebus_namespace a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -206,7 +213,8 @@ query "servicebus_use_virtual_service_endpoint" {
       azure_subscription as sub
       left join service_bus on true
     where
-      sub.subscription_id = bus.subscription_id;
+      sub.subscription_id = bus.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "bus.")};
   EOQ
 }
 
@@ -229,7 +237,10 @@ query "servicebus_namespace_azure_ad_authentication_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_servicebus_namespace a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -256,6 +267,9 @@ query "servicebus_namespace_no_overly_permissive_network_access" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_servicebus_namespace a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/servicefabric.pp
+++ b/regulatory_compliance/servicefabric.pp
@@ -49,7 +49,7 @@ query "servicefabric_cluster_active_directory_authentication_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -73,6 +73,6 @@ query "servicefabric_cluster_protection_level_as_encrypt_and_sign" {
       azure_subscription sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/servicefabric.pp
+++ b/regulatory_compliance/servicefabric.pp
@@ -46,7 +46,10 @@ query "servicefabric_cluster_active_directory_authentication_enabled" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_service_fabric_cluster a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -67,6 +70,9 @@ query "servicefabric_cluster_protection_level_as_encrypt_and_sign" {
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}
     from
       azure_service_fabric_cluster a,
-      azure_subscription sub;
+      azure_subscription sub
+    where
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/signalr.pp
+++ b/regulatory_compliance/signalr.pp
@@ -55,7 +55,8 @@ query "signalr_service_private_link_used" {
       left join signalr_service_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -75,6 +76,7 @@ query "signalr_service_no_free_tier_sku" {
       azure_signalr_service as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/springcloud.pp
+++ b/regulatory_compliance/springcloud.pp
@@ -37,6 +37,7 @@ query "spring_cloud_service_network_injection_enabled" {
       azure_spring_cloud_service as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/sql.pp
+++ b/regulatory_compliance/sql.pp
@@ -255,7 +255,7 @@ query "sql_server_and_databases_va_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -279,7 +279,7 @@ query "sql_server_transparent_data_encryption_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = db.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "db.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "db.")};
   EOQ
 }
 
@@ -304,7 +304,7 @@ query "sql_server_auditing_on" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -337,7 +337,7 @@ query "sql_server_use_virtual_service_endpoint" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -362,7 +362,7 @@ query "sql_server_tde_protector_cmk_encrypted" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -393,7 +393,7 @@ query "sql_database_long_term_geo_redundant_backup_enabled" {
     where
       sub.subscription_id = s.subscription_id
       and s.name <> 'master'
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -432,7 +432,7 @@ query "sql_database_vulnerability_findings_resolved" {
     where
       a.name <> 'master'
       and sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -457,7 +457,7 @@ query "sql_database_transparent_data_encryption_enabled" {
     where
       sub.subscription_id = s.subscription_id
       and s.name <> 'master'
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -494,7 +494,7 @@ query "sql_server_azure_defender_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -528,7 +528,7 @@ query "sql_server_azure_ad_authentication_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -552,7 +552,7 @@ query "sql_db_public_network_access_disabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -586,7 +586,7 @@ query "sql_server_uses_private_link" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -630,7 +630,7 @@ query "sql_server_auditing_storage_account_destination_retention_90_days" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -658,7 +658,7 @@ query "sql_database_allow_internet_access" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -682,7 +682,7 @@ query "sql_db_active_directory_admin_configured" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -707,7 +707,7 @@ query "sql_server_atp_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -734,7 +734,7 @@ query "sql_server_auditing_retention_period_90" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -776,7 +776,7 @@ query "sql_server_va_setting_periodic_scan_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -818,7 +818,7 @@ query "sql_server_va_setting_reports_notify_admins" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -860,7 +860,7 @@ query "sql_server_va_setting_scan_reports_configured" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -894,6 +894,6 @@ query "sql_server_threat_detection_all_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/sql.pp
+++ b/regulatory_compliance/sql.pp
@@ -254,7 +254,8 @@ query "sql_server_and_databases_va_enabled" {
       jsonb_array_elements(server_vulnerability_assessment) assessment,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -277,7 +278,8 @@ query "sql_server_transparent_data_encryption_enabled" {
       azure_sql_database db,
       azure_subscription sub
     where
-      sub.subscription_id = db.subscription_id;
+      sub.subscription_id = db.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "db.")};
   EOQ
 }
 
@@ -301,7 +303,8 @@ query "sql_server_auditing_on" {
       jsonb_array_elements(server_audit_policy) audit,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -333,7 +336,8 @@ query "sql_server_use_virtual_service_endpoint" {
       left join sql_server_subnet as s on a.name = s.name,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -357,7 +361,8 @@ query "sql_server_tde_protector_cmk_encrypted" {
       jsonb_array_elements(encryption_protector) encryption,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -387,7 +392,8 @@ query "sql_database_long_term_geo_redundant_backup_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = s.subscription_id
-      and s.name <> 'master';
+      and s.name <> 'master'
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -425,7 +431,8 @@ query "sql_database_vulnerability_findings_resolved" {
       azure_subscription as sub
     where
       a.name <> 'master'
-      and sub.subscription_id = a.subscription_id;
+      and sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -449,7 +456,8 @@ query "sql_database_transparent_data_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-      and s.name <> 'master';
+      and s.name <> 'master'
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -485,7 +493,8 @@ query "sql_server_azure_defender_enabled" {
       left join sql_server_policy as s on a.name = s.name,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -518,7 +527,8 @@ query "sql_server_azure_ad_authentication_enabled" {
       left join sever_with_ad_admin as s on a.id = s.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -541,7 +551,8 @@ query "sql_db_public_network_access_disabled" {
       azure_sql_server as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -574,7 +585,8 @@ query "sql_server_uses_private_link" {
       left join sql_server_private_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -617,7 +629,8 @@ query "sql_server_auditing_storage_account_destination_retention_90_days" {
       left join sql_server as s on s.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -644,7 +657,8 @@ query "sql_database_allow_internet_access" {
       azure_sql_server s,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -667,7 +681,8 @@ query "sql_db_active_directory_admin_configured" {
       azure_sql_server s,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -691,7 +706,8 @@ query "sql_server_atp_enabled" {
       jsonb_array_elements(server_security_alert_policy) security,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -717,7 +733,8 @@ query "sql_server_auditing_retention_period_90" {
       jsonb_array_elements(server_audit_policy) audit,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -758,7 +775,8 @@ query "sql_server_va_setting_periodic_scan_enabled" {
       jsonb_array_elements(server_vulnerability_assessment) assessment,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -799,7 +817,8 @@ query "sql_server_va_setting_reports_notify_admins" {
       jsonb_array_elements(server_vulnerability_assessment) assessment,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -840,7 +859,8 @@ query "sql_server_va_setting_scan_reports_configured" {
       jsonb_array_elements(server_vulnerability_assessment) assessment,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -873,6 +893,7 @@ query "sql_server_threat_detection_all_enabled" {
       left join threat_detection_disabled as t on t.id = s.id,
       azure_subscription sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/storage.pp
+++ b/regulatory_compliance/storage.pp
@@ -251,7 +251,7 @@ query "storage_account_secure_transfer_required_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -275,7 +275,7 @@ query "storage_account_default_network_access_rule_denied" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -314,7 +314,7 @@ query "storage_account_use_virtual_service_endpoint" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -348,7 +348,7 @@ query "storage_account_uses_private_link" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -372,7 +372,7 @@ query "storage_account_infrastructure_encryption_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -396,7 +396,7 @@ query "storage_account_block_public_access" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -420,7 +420,7 @@ query "storage_account_restrict_network_access" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -444,7 +444,7 @@ query "storage_account_geo_redundant_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -468,7 +468,7 @@ query "storage_account_encryption_at_rest_using_cmk" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -492,7 +492,7 @@ query "storage_account_uses_azure_resource_manager" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -528,7 +528,7 @@ query "storage_account_encryption_scopes_encrypted_at_rest_with_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -552,7 +552,7 @@ query "storage_account_blob_containers_public_access_private" {
       azure_storage_container container
       join azure_storage_account account on container.account_name = account.name
       join azure_subscription sub on sub.subscription_id = account.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "account.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "account.")}
   EOQ
 }
 
@@ -585,7 +585,7 @@ query "storage_account_blob_service_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -615,7 +615,7 @@ query "storage_account_table_service_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -641,7 +641,7 @@ query "storage_account_min_tls_1_2" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -671,7 +671,7 @@ query "storage_account_queue_services_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -695,7 +695,7 @@ query "storage_account_soft_delete_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -719,7 +719,7 @@ query "storage_account_trusted_microsoft_services_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -754,7 +754,7 @@ query "storage_account_blobs_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -786,7 +786,7 @@ query "storage_account_tables_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -818,7 +818,7 @@ query "storage_account_queues_logging_enabled" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -847,6 +847,6 @@ query "storage_account_containing_vhd_os_disk_cmk_encrypted" {
     where
       sub.subscription_id = sa.subscription_id
       and vm.os_disk_vhd_uri like '%' || sa.name || '%'
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }

--- a/regulatory_compliance/storage.pp
+++ b/regulatory_compliance/storage.pp
@@ -250,7 +250,8 @@ query "storage_account_secure_transfer_required_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -273,7 +274,8 @@ query "storage_account_default_network_access_rule_denied" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -311,7 +313,8 @@ query "storage_account_use_virtual_service_endpoint" {
       left join storage_account_subnet as s on a.id = s.storage_account_id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -344,7 +347,8 @@ query "storage_account_uses_private_link" {
       left join storage_account_connection as s on a.id = s.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")}
   EOQ
 }
 
@@ -367,7 +371,8 @@ query "storage_account_infrastructure_encryption_enabled" {
       azure_storage_account as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -390,7 +395,8 @@ query "storage_account_block_public_access" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -413,7 +419,8 @@ query "storage_account_restrict_network_access" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -436,7 +443,8 @@ query "storage_account_geo_redundant_enabled" {
       azure_storage_account as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -459,7 +467,8 @@ query "storage_account_encryption_at_rest_using_cmk" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -482,7 +491,8 @@ query "storage_account_uses_azure_resource_manager" {
       azure_storage_account as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -517,7 +527,8 @@ query "storage_account_encryption_scopes_encrypted_at_rest_with_cmk" {
       storage_account_encryption_scope as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")}
   EOQ
 }
 
@@ -540,7 +551,8 @@ query "storage_account_blob_containers_public_access_private" {
     from
       azure_storage_container container
       join azure_storage_account account on container.account_name = account.name
-      join azure_subscription sub on sub.subscription_id = account.subscription_id;
+      join azure_subscription sub on sub.subscription_id = account.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "account.")}
   EOQ
 }
 
@@ -572,7 +584,8 @@ query "storage_account_blob_service_logging_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -601,7 +614,8 @@ query "storage_account_table_service_logging_enabled" {
       azure_storage_account as sa,
       azure_subscription as sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -626,7 +640,8 @@ query "storage_account_min_tls_1_2" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -655,7 +670,8 @@ query "storage_account_queue_services_logging_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -678,7 +694,8 @@ query "storage_account_soft_delete_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -701,7 +718,8 @@ query "storage_account_trusted_microsoft_services_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -735,7 +753,8 @@ query "storage_account_blobs_logging_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -766,7 +785,8 @@ query "storage_account_tables_logging_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -797,7 +817,8 @@ query "storage_account_queues_logging_enabled" {
       azure_storage_account sa,
       azure_subscription sub
     where
-      sub.subscription_id = sa.subscription_id;
+      sub.subscription_id = sa.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }
 
@@ -825,6 +846,7 @@ query "storage_account_containing_vhd_os_disk_cmk_encrypted" {
       azure_subscription sub
     where
       sub.subscription_id = sa.subscription_id
-      and vm.os_disk_vhd_uri like '%' || sa.name || '%';
+      and vm.os_disk_vhd_uri like '%' || sa.name || '%'
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "sa.")}
   EOQ
 }

--- a/regulatory_compliance/storagesync.pp
+++ b/regulatory_compliance/storagesync.pp
@@ -48,6 +48,6 @@ query "storage_sync_private_link_used" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/storagesync.pp
+++ b/regulatory_compliance/storagesync.pp
@@ -47,6 +47,7 @@ query "storage_sync_private_link_used" {
       left join storagesync_service_connection as c on c.id = a.id,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }

--- a/regulatory_compliance/streamanalytics.pp
+++ b/regulatory_compliance/streamanalytics.pp
@@ -23,7 +23,7 @@ control "stream_analytics_job_encrypted_with_cmk" {
   query       = query.manual_control
 
   tags = merge(local.regulatory_compliance_streamanalytics_common_tags, {
-    nist_sp_800_53_rev_5  = "true"
+    nist_sp_800_53_rev_5 = "true"
   })
 }
 
@@ -74,6 +74,7 @@ query "stream_analytics_job_logging_enabled" {
       left join logging_details as l on v.name = l.job_name,
       azure_subscription as sub
     where
-      sub.subscription_id = v.subscription_id;
+      sub.subscription_id = v.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }

--- a/regulatory_compliance/streamanalytics.pp
+++ b/regulatory_compliance/streamanalytics.pp
@@ -75,6 +75,6 @@ query "stream_analytics_job_logging_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = v.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "v.")};
   EOQ
 }

--- a/regulatory_compliance/synapse.pp
+++ b/regulatory_compliance/synapse.pp
@@ -69,7 +69,7 @@ query "synapse_workspace_private_link_used" {
       azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -106,7 +106,7 @@ query "synapse_workspace_vulnerability_assessment_enabled" {
     azure_subscription as sub
     where
       sub.subscription_id = a.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -130,7 +130,7 @@ query "synapse_workspace_encryption_at_rest_using_cmk" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -154,6 +154,6 @@ query "synapse_workspace_data_exfiltration_protection_enabled" {
       azure_subscription as sub
     where
       sub.subscription_id = s.subscription_id
-    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
+      ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/regulatory_compliance/synapse.pp
+++ b/regulatory_compliance/synapse.pp
@@ -68,7 +68,8 @@ query "synapse_workspace_private_link_used" {
       azure_synapse_workspace as a,
       azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -104,7 +105,8 @@ query "synapse_workspace_vulnerability_assessment_enabled" {
     left join synapse_workspace as s on s.id = a.id,
     azure_subscription as sub
     where
-      sub.subscription_id = a.subscription_id;
+      sub.subscription_id = a.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "a.")};
   EOQ
 }
 
@@ -127,7 +129,8 @@ query "synapse_workspace_encryption_at_rest_using_cmk" {
       azure_synapse_workspace as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }
 
@@ -150,6 +153,7 @@ query "synapse_workspace_data_exfiltration_protection_enabled" {
       azure_synapse_workspace as s,
       azure_subscription as sub
     where
-      sub.subscription_id = s.subscription_id;
+      sub.subscription_id = s.subscription_id
+    ${replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "s.")};
   EOQ
 }

--- a/variables.pp
+++ b/variables.pp
@@ -28,6 +28,12 @@ variable "tag_dimensions" {
   default = []
 }
 
+variable "resource_group_filter" {
+  type        = list(string)
+  description = "A list of resource group names to filter all queries. If empty, no resource group filtering is applied."
+  default     = [""]
+}
+
 locals {
   # Local internal variable to build the SQL select clause for common
   # dimensions using a table name qualifier if required. Do not edit directly.
@@ -57,6 +63,12 @@ locals {
   # dimensions. Do not edit directly.
   tag_dimensions_qualifier_sql = <<-EOQ
   %{~for dim in var.tag_dimensions},  __QUALIFIER__tags ->> '${dim}' as "${replace(dim, "\"", "\"\"")}"%{endfor~}
+  EOQ
+
+  resource_group_filter_sql = <<-EOQ
+  %{~if length(var.resource_group_filter) > 0}
+    and resource_group in (${join(", ", [for rg in var.resource_group_filter : "'${rg}'"])})
+  %{endif~}
   EOQ
 }
 

--- a/variables.pp
+++ b/variables.pp
@@ -31,7 +31,7 @@ variable "tag_dimensions" {
 variable "resource_group_filter" {
   type        = list(string)
   description = "A list of resource group names to filter all queries. If empty, no resource group filtering is applied."
-  default     = [""]
+  default     = []
 }
 
 locals {
@@ -65,9 +65,9 @@ locals {
   %{~for dim in var.tag_dimensions},  __QUALIFIER__tags ->> '${dim}' as "${replace(dim, "\"", "\"\"")}"%{endfor~}
   EOQ
 
-  resource_group_filter_sql = <<-EOQ
+  resource_group_filter_qualifier_sql = <<-EOQ
   %{~if length(var.resource_group_filter) > 0}
-    and resource_group in (${join(", ", [for rg in var.resource_group_filter : "'${rg}'"])})
+    and __QUALIFIER__resource_group in (${join(", ", [for rg in var.resource_group_filter : "'${rg}'"])})
   %{endif~}
   EOQ
 }
@@ -80,4 +80,5 @@ locals {
   common_dimensions_subscription_sql    = replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "")
   common_dimensions_subscription_id_sql = replace(local.common_dimensions_subscription_id_qualifier_sql, "__QUALIFIER__", "")
   tag_dimensions_sql                    = replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "")
+  resource_group_filter_sql             = replace(local.resource_group_filter_qualifier_sql, "__QUALIFIER__", "")
 }


### PR DESCRIPTION
When I run all_controls benchmark with resource_group_filter=["new_rg", "myresourcegroup"]
```
powerpipe benchmark run azure_compliance.benchmark.all_controls --var 'resource_group_filter=["new_rg", "myresourcegroup"]'
All Controls ........................................................................................................ 53 / 81 [==========]
| |   
+ Security Center ................................................................................................... 15 / 39 [=====     ]
| | 
| + Ensure 'Additional email addresses' is configured with a security contact email .................................  1 /  1 [=         ]
| | | 
| | ALARM: Additional email addresses not configured. ......................... azure newwarriors AAA
| | 
| + Ensure any of the ASC Default policy setting is not set to "Disabled" ...........................................  0 /  1 [=         ]
| | | 
| | OK   : Settings enabled for all the parameters. ........................... azure newwarriors AAA
| | 
| + Auto provisioning of the Log Analytics agent should be enabled on your subscription .............................  1 /  1 [=         ]
| | | 
| | ALARM: Automatic provisioning of monitoring agent is off. ................. azure newwarriors AAA
| | 
| + Storage accounts should use private link ........................................................................  0 /  0 [          ]
OK ........................... 27 [====      ]
SKIP .......................... 1 [=         ]
INFO ......................... 0 [          ]
ALARM ...................... 41 [======    ]
ERROR ...................... 12 [==        ]

TOTAL ....................... 53 / 81 [==========]
```
When I run powerpipe server with resource_group_filter=["new_rg", "myresourcegroup"] in .ppvars file
![screencapture-localhost-9033-azure-compliance-benchmark-all-controls-2025-05-16-01_35_04](https://github.com/user-attachments/assets/a9aaf13f-82d4-48b8-94f6-2a32aa777d95)
