### PR TITLE
Update benchmark children in cis_v400 and nist_csf_v2 to include missing entries for cis_v400_10 and nist_csf_v2_id_ra_04

### DIFF
--- a/cis_v400/cis.pp
+++ b/cis_v400/cis.pp
@@ -11,7 +11,6 @@ benchmark "cis_v400" {
   documentation = file("./cis_v400/docs/cis_overview.md")
 
   children = [
-    benchmark.cis_v400_10,
     benchmark.cis_v400_2,
     benchmark.cis_v400_3,
     benchmark.cis_v400_4,
@@ -19,6 +18,7 @@ benchmark "cis_v400" {
     benchmark.cis_v400_7,
     benchmark.cis_v400_8,
     benchmark.cis_v400_9,
+    benchmark.cis_v400_10
   ]
 
   tags = merge(local.cis_v400_common_tags, {

--- a/nist_csf_v2/function_id.pp
+++ b/nist_csf_v2/function_id.pp
@@ -108,6 +108,7 @@ benchmark "nist_csf_v2_id_ra" {
   children = [
     benchmark.nist_csf_v2_id_ra_01,
     benchmark.nist_csf_v2_id_ra_03,
+    benchmark.nist_csf_v2_id_ra_04,
     benchmark.nist_csf_v2_id_ra_05,
     benchmark.nist_csf_v2_id_ra_08,
     benchmark.nist_csf_v2_id_ra_09


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
