### PR TITLE
Fix CIS query `iam_global_administrator_max_5` to correctly check min 2 and max 5 global administrators

### DIFF
--- a/regulatory_compliance/iam.pp
+++ b/regulatory_compliance/iam.pp
@@ -850,7 +850,7 @@ query "iam_global_administrator_max_5" {
     select
       t.tenant_id as resource,
       case
-        when jsonb_array_length(member_ids) <= 5 then 'ok'
+        when jsonb_array_length(member_ids) >= 2 and jsonb_array_length(member_ids) < 5 then 'ok'
         else 'alarm'
       end as status,
       t.title || ' has ' ||  (jsonb_array_length(member_ids)) || ' users with global administrator assignment.'  as reason,


### PR DESCRIPTION

### Checklist
```
with distinct_tenant as (
      select
        distinct tenant_id,
        title,
        subscription_id,
        _ctx
      from
        azure_tenant
    )
    select
      t.tenant_id as resource,
      case
        when jsonb_array_length(member_ids) >= 2 and jsonb_array_length(member_ids) < 5 then 'ok'
        else 'alarm'
      end as status,
      t.title || ' has ' ||  (jsonb_array_length(member_ids)) || ' users with global administrator assignment.'  as reason,
      t.tenant_id
    from
      distinct_tenant as t,
      azuread_directory_role
    where
      display_name = 'Global Administrator'
+--------------------------------------+--------+-----------------------------------------------------------+--------------------------------------+
| resource                             | status | reason                                                    | tenant_id                            |
+--------------------------------------+--------+-----------------------------------------------------------+--------------------------------------+
| xxxxxxxx-xxxxx-xxxx-xxxx-xxxxxxxx | alarm  | turbot has 18 users with global administrator assignment. | xxxxxxxx-xxxxx-xxxx-xxxx-xxxxxxxx|
+--------------------------------------+--------+-----------------------------------------------------------+--------------------------------------+
````
