### PR TITLE
Update query `kubernetes_cluster_sku_standard` to check SKU tier `Standard` instead of deprecated 'Paid' from API response

### DIFF
--- a/regulatory_compliance/kubernetes.pp
+++ b/regulatory_compliance/kubernetes.pp
@@ -532,12 +532,12 @@ query "kubernetes_cluster_sku_standard" {
     select
       c.id as resource,
       case
-        when sku ->> 'tier' = 'Standard' then 'ok'
-        else 'alarm'
+        when sku ->> 'tier' = 'Free' then 'alarm'
+        else 'ok'
       end as status,
       case
-        when sku ->> 'tier' = 'Standard' then c.name || ' uses standard SKU tier.'
-        else c.name || ' uses free SKU tier.'
+        when sku ->> 'tier' = 'Free' then c.name || ' uses free SKU tier.'
+        else c.name || ' uses ' || (sku ->> 'tier') || ' SKU tier.'
       end as reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}
       ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}

--- a/regulatory_compliance/kubernetes.pp
+++ b/regulatory_compliance/kubernetes.pp
@@ -532,11 +532,11 @@ query "kubernetes_cluster_sku_standard" {
     select
       c.id as resource,
       case
-        when sku ->> 'tier' = 'Paid' then 'ok'
+        when sku ->> 'tier' = 'Standard' then 'ok'
         else 'alarm'
       end as status,
       case
-        when sku ->> 'tier' = 'Paid' then c.name || ' uses standard SKU tier.'
+        when sku ->> 'tier' = 'Standard' then c.name || ' uses standard SKU tier.'
         else c.name || ' uses free SKU tier.'
       end as reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}


### PR DESCRIPTION
```
select
      c.id as resource,
      case
        when sku ->> 'tier' = 'Standard' then 'ok'
        else 'alarm'
      end as status,
      case
        when sku ->> 'tier' = 'Standard' then c.name || ' uses standard SKU tier.'
        else c.name || ' uses free SKU tier.'
      end as reason
    from
      azure.azure_kubernetes_cluster c
      left join azure.azure_subscription as sub on sub.subscription_id = c.subscription_id;
+-----------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------+
| resource                                                                                                                          | status | reason                       |
+-----------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------+
| /subscriptions/xxxxxx-xxxxxxx-xxxx-xxxx-xxxxxxxx/resourcegroups/demo/providers/Microsoft.ContainerService/managedClusters/test | ok     | test uses standard SKU tier. |
+-----------------------------------------------------------------------------------------------------------------------------------+--------+------------------------------+

```
