### PR TITLE
fix notifications by role control

### DIFF
--- a/regulatory_compliance/securitycenter.pp
+++ b/regulatory_compliance/securitycenter.pp
@@ -332,10 +332,12 @@ query "securitycenter_security_alerts_to_owner_enabled" {
   sql = <<-EOQ
     with contact_info as (
       select
-        count(*) filter (where alerts_to_admins = 'On') as admin_alert_count,
+        count(*) as admin_alert_count,
         subscription_id
       from
         azure_security_center_contact
+      where
+        notifications_by_role @> '{"roles": ["Owner"]}' and notifications_by_role @> '{"state": "On"}'
       group by
         subscription_id
       limit 1


### PR DESCRIPTION
## Problem statement
`alerts_to_admins` field is no longer supported by Azure API. It was deprecated in favour of `notifications_by_role` (ref: https://learn.microsoft.com/en-us/rest/api/defenderforcloud/security-contacts/create?view=rest-defenderforcloud-2023-12-01-preview&tabs=HTTP#notificationsbyrole).

Deprecation by Microsoft was reflected in [steampipe-plugin-azure/azure/table_azure_security_center_contact.go](https://github.com/turbot/steampipe-plugin-azure/commit/681b926ca21231ad13001f968303b36380c69446#diff-691a50b845889f2b85495506efee9565bc9265510737675b5fc0f2dc7db8d61bR69) and even though the field has been kept in the plugin for backward compatibility reasons, it no longer returns any usable information, defaulting to `null`.

#### Example: 

```sql
SELECT * FROM azure_security_center_contact;
```

<img width="721" height="184" alt="image" src="https://github.com/user-attachments/assets/24ebe0d9-97a8-4c17-8b50-a743a576ae66" />


Above renders the following query (`securitycenter_security_alerts_to_owner_enabled`) invalid, as it returns no results. This in consequence affects CIS v5.0.0 - 8.1.12 control, by raising false positives.

## Solution

Modified `securitycenter_security_alerts_to_owner_enabled` query observes `notifications_by_role` field and validates that at least one role is set to `"Owner"` and `state` is `"On"`.

The proposed change aligns the control with the original specification, which was corrected by CIS in their latest revision (v5.0.0):
<img width="1794" height="1024" alt="image" src="https://github.com/user-attachments/assets/e9720521-9d10-4695-babc-52cf742c4778" />
