### PR TITLE
Makes query for CIS v5.0.0 - 9.3.1.1 control more tolerant

### DIFF
--- a/regulatory_compliance/storage.pp
+++ b/regulatory_compliance/storage.pp
@@ -1224,7 +1224,7 @@ query "storage_account_key_rotation_reminder_enabled" {
       sa.id as resource,
       case
         when key_policy is null then 'alarm'
-        when key_policy ->> 'keyExpirationPeriodInDays' <= '90' then 'ok'
+        when (key_policy ->> 'keyExpirationPeriodInDays')::int <= 90 then 'ok'
         else 'alarm'
       end as status,
       case


### PR DESCRIPTION
## Problem statement

`storage_account_key_rotation_reminder_enabled` query strictly validates whether key rotation reminders are set EXACTLY to 90 days. This condition is too strict and will fail for any other value which, by the way, by default (Microsoft Azure default setting) is set to 60 days, which is even more frequent.

CIS recommends 90 days but clarifies that organization should trim it even further:

> For the purposes of this recommendation, 90 days will be prescribed for the reminder. Review and adjustment of the 90 day period is recommended, and may even be necessary. Your organization's security requirements should dictate the appropriate setting. 

## Solution

Make the query inclusive by checking whether the value is lower or equal to 90.

#### Before: 
<img width="721" height="184" alt="image" src="https://github.com/user-attachments/assets/c9b64f95-5126-4b18-a95c-5e328a3674f0" />

- Account with the value set to WEEKLY (set in MS Azure Portal) fails the benchmark


#### After:
<img width="721" height="184" alt="image" src="https://github.com/user-attachments/assets/89f81dba-8f60-4ace-a52d-48ca0369ef7e" />

- Account with the value set to WEEKLY (set in MS Azure Portal) passes the benchmark
