### PR TITLE
Fixed the `storage_account_file_share_soft_delete_enabled` query to use coalesce to handle `NULL` values correctly

### DIFF
--- a/regulatory_compliance/storage.pp
+++ b/regulatory_compliance/storage.pp
@@ -985,7 +985,7 @@ query "storage_account_file_share_soft_delete_enabled" {
       end as status,
       case
         when fs.storage_account_name is null then name || ' does not have file share.'
-        when not file_soft_delete_enabled then name || ' file share soft delete disabled.'
+        when not coalesce(file_soft_delete_enabled, false) then name || ' file share soft delete disabled.'
         when file_soft_delete_retention_days < 1 or file_soft_delete_retention_days > 365
           then name || ' file share soft delete retention days (' || file_soft_delete_retention_days || ') not between 1 and 365.'
         else name || ' file share soft delete enabled with ' || file_soft_delete_retention_days || ' days retention.'


### PR DESCRIPTION
When `file_soft_delete_retention_days` is `null` the "not" case is not reachable, and causes `reason` to be `null`

Evidence before:
<img width="1620" height="554" alt="image" src="https://github.com/user-attachments/assets/7aabefd8-240c-434c-843d-5a6e1e3331fd" />


After change:
<img width="1620" height="554" alt="image" src="https://github.com/user-attachments/assets/58ef4e06-f6b4-4fe0-8916-171043060254" />
