### PR TITLE
Align network_ddos_enabled query with resource ID convention

### DIFF
--- a/regulatory_compliance/network.pp
+++ b/regulatory_compliance/network.pp
@@ -700,7 +700,7 @@ query "network_ddos_enabled" {
         jsonb_array_elements(gateway_ip_configurations) as c
     )
     select
-      a.name as resource,
+      a.id as resource,
       case
         when b.vn_name is null then 'ok'
         when b.vn_name is not null and enable_ddos_protection::bool then 'ok'


### PR DESCRIPTION
### Resolves: 
- https://github.com/turbot/steampipe-mod-azure-compliance/issues/366

### Problem
The `network_ddos_enabled` resource property is inconsistent with established conventions, where resource identifiers are typically returned.

Specifically, the `network_ddos_enabled` query - used by CIS Benchmark for Azure v5.0.0, control 8.5 - currently relies on the `name` property instead of the resource `id`.

### Solution
This PR updates the query to return the resource `id`, aligning it with existing conventions and ensuring consistency across resource properties.