### PR TITLE
Fixes CIS v5.0.0 control 8.1.14 issue caused by deprecated fields

### DIFF
--- a/regulatory_compliance/securitycenter.pp
+++ b/regulatory_compliance/securitycenter.pp
@@ -302,7 +302,8 @@ query "securitycenter_notify_alerts_configured" {
   sql = <<-EOQ
     with contact_info as (
       select
-        count(*) filter (where alert_notifications = 'On') as notification_alert_count,
+        count(*) filter (where notifications_by_role @> '{"state": "On"}') as notifications_on_count,
+        count(*) filter (where notifications_sources @> '[{"sourceType": "Alert", "minimalSeverity": "High"}]') as alert_severity_count,
         subscription_id
       from
         azure_security_center_contact
@@ -313,12 +314,13 @@ query "securitycenter_notify_alerts_configured" {
     select
       sub.subscription_id as resource,
       case
-        when notification_alert_count > 0 then 'ok'
+        when notifications_on_count > 0 and alert_severity_count > 0 then 'ok'
         else 'alarm'
       end as status,
       case
-        when notification_alert_count > 0 then '"Notify about alerts with the following severity" set to High.'
-        else '"Notify about alerts with the following severity" not set to High.'
+        when notifications_on_count > 0 and alert_severity_count > 0 then '"Notify about alerts with the following severity" set to High.'
+        when notifications_on_count > 0 then '"Notify about alerts with the following severity" not set to High.'
+        else 'Notifications state is not set to "On".'
       end as reason
       ${replace(local.common_dimensions_subscription_id_qualifier_sql, "__QUALIFIER__", "sub.")}
       ${replace(local.common_dimensions_qualifier_subscription_sql, "__QUALIFIER__", "sub.")}


### PR DESCRIPTION
## Problem statement

`alert_notifications` field is no longer supported by Azure API. It was deprecated in favour of `notifications_sources` (ref: [https://learn.microsoft.com/en-us/rest/api/defenderforcloud/security-contacts/create?view=rest-defenderforcloud-2023-12-01-preview&tabs=HTTP#notificationssource](https://learn.microsoft.com/en-us/rest/api/defenderforcloud/security-contacts/create?view=rest-defenderforcloud-2023-12-01-preview&tabs=HTTP#notificationssource)).

Deprecation by Microsoft was reflected in [steampipe-plugin-azure/azure/table_azure_security_center_contact.go](https://github.com/turbot/steampipe-plugin-azure/commit/681b926ca21231ad13001f968303b36380c69446#diff-691a50b845889f2b85495506efee9565bc9265510737675b5fc0f2dc7db8d61bR63) and even though the field has been kept in the plugin for backward
compatibility reasons, it no longer returns any usable information, defaulting to `null`.

Above renders the following query (`securitycenter_notify_alerts_configured`) invalid, as it returns no results. This in consequence affects CIS v5.0.0 -
8.1.14 control, by raising false positives.

## Solution

Modified `securitycenter_notify_alerts_configured` query observes `notifications_sources` field to validate that at least one source is set to `"Alert"` with `minimalSeverity` of `"High"`, and `notifications_by_role` field to validate that the notification state is `"On"`. Reason is populated respectively depending on which condition fails.

The proposed change aligns the control with the original specification, which
was corrected by CIS in their latest revision (v5.0.0).

### Change summary

- Replaced deprecated `alert_notifications` field with two non-deprecated fields: `notifications_by_role` and `notifications_sources`
- Uses `notifications_by_role @> '{"state": "On"}'` to verify notifications are enabled
- Uses `notifications_sources @> '[{"sourceType": "Alert", "minimalSeverity": "High"}]'` to verify alert severity is set to High
- Two separate `filter` counts allow the reason to indicate which specific condition failed
- Reason now distinguishes between notifications not being "On" vs. severity not set to High

### Related

- PR #352: fix notifications by role control (8.1.12) — same class of issue with `alerts_to_admins` → `notifications_by_role`
